### PR TITLE
Support use.id.as.filename in chunking.

### DIFF
--- a/xslt/base/html/chunkfunc.xsl
+++ b/xslt/base/html/chunkfunc.xsl
@@ -23,12 +23,15 @@
     <xsl:variable name="pifn" select="f:pi($chunk/processing-instruction('dbhtml'), 'filename')"/>
 
     <xsl:choose>
-      <xsl:when test="string($pifn) = ''">
-        <xsl:value-of select="concat('chunk-', local-name($chunk),
-                                     '-', generate-id($chunk), $html.ext)"/>
+      <xsl:when test="string($pifn) != ''">
+	<xsl:value-of select="$pifn"/>
+      </xsl:when>
+      <xsl:when test="$chunk/@xml:id and $use.id.as.filename != '0'">
+	<xsl:value-of select="concat($chunk/@xml:id,$html.ext)"/>
       </xsl:when>
       <xsl:otherwise>
-        <xsl:value-of select="$pifn"/>
+        <xsl:value-of select="concat('chunk-', local-name($chunk),
+                                     '-', generate-id($chunk), $html.ext)"/>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:function>


### PR DESCRIPTION
It appears that use.id.as.filename had not yet been implemented. This takes the pi first, if it exists, then the chunk's xml:id, if one exists, otherwise it generates a name.
