### PR TITLE
2 fixes in 4-normalize.xsl

### DIFF
--- a/xslt/base/preprocess/4-normalize.xsl
+++ b/xslt/base/preprocess/4-normalize.xsl
@@ -517,6 +517,14 @@ if appropriate</refpurpose>
   <xsl:apply-templates select="$normalized" mode="m:verbatim-phase-1"/>
 </xsl:template>
 
+<!-- HACK: m:verbatim-phase-1 was not implemented. This is a temporary noop implementation that at least 
+     does not strip verbatim elements. -->
+<xsl:template match="@*|node()" mode="m:verbatim-phase-1" xmlns:m="http://docbook.org/xslt/ns/mode">
+  <xsl:copy>
+    <xsl:apply-templates select="@*|node()" mode="m:verbatim-phase-1"/>
+  </xsl:copy>
+</xsl:template>
+
 <xsl:template match="*" mode="m:normalize">
   <xsl:choose>
     <xsl:when test="db:title|db:subtitle|db:titleabbrev|db:info/db:title">


### PR DESCRIPTION
1. Do not drop titles when there is a db:title and a db:info in the same element. 
2. Temporary template to handle mode="m:verbatim-phase-1" instead of dropping verbatim elements. 
