### PR TITLE
Split slide resources from the shared $resource.root

### DIFF
--- a/xslt/slides/fo/plain.xsl
+++ b/xslt/slides/fo/plain.xsl
@@ -18,6 +18,7 @@
 <xsl:param name="slide.title.font.family">sans-serif</xsl:param>
 <xsl:param name="foil.title.master">28</xsl:param>
 <xsl:param name="body.font.size">24pt</xsl:param>
+<xsl:param name="resource.slide" select="$resource.root"/>
 
 <xsl:param name="footnote.number.symbols" select="'*†'"/>
 
@@ -211,7 +212,7 @@
     <fo:region-body margin-bottom="0pt"
                     margin-top="0pt"
                     column-count="{$column.count.body}"
-                    background-image="url({$resource.root}img/print/title.png)"
+                    background-image="url({$resource.slide}print/title.png)"
                     background-attachment="fixed"
                     background-repeat="no-repeat"
                     background-position-horizontal="left"
@@ -236,7 +237,7 @@
     <fo:region-before region-name="xsl-region-before-foil"
                       extent="1.5in"
                       display-align="before"
-                      background-image="url({$resource.root}img/print/foil.png)"
+                      background-image="url({$resource.slide}print/foil.png)"
                       background-attachment="fixed"
                       background-repeat="no-repeat"
                       background-position-horizontal="left"
@@ -260,7 +261,7 @@
     <fo:region-before region-name="xsl-region-before-foil-continued"
                       extent="1.5in"
                       display-align="before"
-                      background-image="url({$resource.root}img/print/foil.png)"
+                      background-image="url({$resource.slide}print/foil.png)"
                       background-attachment="fixed"
                       background-repeat="no-repeat"
                       background-position-horizontal="left"
@@ -280,7 +281,7 @@
     <fo:region-body margin-bottom="0pt"
                     margin-top="0pt"
                     column-count="{$column.count.body}"
-                    background-image="url({$resource.root}img/print/group.png)"
+                    background-image="url({$resource.slide}print/group.png)"
                     background-attachment="fixed"
                     background-repeat="no-repeat"
                     background-position-horizontal="left"
@@ -352,7 +353,7 @@
   <xsl:variable name="content">
     <fo:block>
       <fo:block-container height="0.75in"
-                          background-image="url({$resource.root}img/print/footer.png)"
+                          background-image="url({$resource.slide}print/footer.png)"
                           background-attachment="fixed"
                           background-repeat="no-repeat"
                           background-position-horizontal="left"

--- a/xslt/slides/html/plain.xsl
+++ b/xslt/slides/html/plain.xsl
@@ -15,6 +15,7 @@
 <xsl:param name="speaker.notes" select="0"/>
 <xsl:param name="localStorage.key" select="'slideno'"/>
 <xsl:param name="group.toc" select="0"/>
+<xsl:param name="resource.slide" select="$resource.root"/>
 
 <xsl:param name="cdn.jquery"
            select="'http://code.jquery.com/jquery-1.6.3.min.js'"/>
@@ -95,18 +96,18 @@
           src="{$cdn.jqueryui}"/>
 
   <script type="text/javascript" language="javascript"
-          src="{$resource.root}js/jquery-timers-1.2.js" />
+          src="{$resource.slide}js/jquery-timers-1.2.js" />
   <script type="text/javascript" language="javascript"
-          src="{$resource.root}js/jquery.ba-hashchange.min.js" />
+          src="{$resource.slide}js/jquery.ba-hashchange.min.js" />
   <script type="text/javascript" language="javascript"
-          src="{$resource.root}../slides/js/slides.js" />
+          src="{$resource.slide}js/slides.js" />
 </xsl:template>
 
 <xsl:template name="t:slides.css">
   <link type="text/css" rel="stylesheet"
         href="{$cdn.jqueryui.css}"/>
   <link type="text/css" rel="stylesheet"
-        href="{$resource.root}../slides/css/slides.css"/>
+        href="{$resource.slide}css/slides.css"/>
 </xsl:template>
 
 <xsl:template name="toc">
@@ -173,8 +174,8 @@
     </div>
     <div class="body">
       <div class="shownav">
-        <img src="{$resource.root}img/prev.gif" alt="[Prev]"/>
-        <img src="{$resource.root}img/next.gif" alt="[Next]"/>
+        <img src="{$resource.slide}img/prev.gif" alt="[Prev]"/>
+        <img src="{$resource.slide}img/next.gif" alt="[Next]"/>
       </div>
       <xsl:call-template name="t:clicknav">
         <xsl:with-param name="next" select="'#toc'"/>
@@ -290,21 +291,21 @@
     <xsl:choose>
       <xsl:when test="exists($prev)">
         <a href="javascript:clicknav('prev')">
-          <img src="{$resource.root}../slides/img/transparent.gif" alt="[Prev]"/>
+          <img src="{$resource.slide}img/transparent.gif" alt="[Prev]"/>
         </a>
       </xsl:when>
       <xsl:otherwise>
-        <img src="{$resource.root}../slides/img/transparent.gif" alt="[Prev]"/>
+        <img src="{$resource.slide}img/transparent.gif" alt="[Prev]"/>
       </xsl:otherwise>
     </xsl:choose>
     <xsl:choose>
       <xsl:when test="exists($next)">
         <a href="javascript:clicknav('next')">
-          <img src="{$resource.root}../slides/img/transparent.gif" alt="[Next]"/>
+          <img src="{$resource.slide}img/transparent.gif" alt="[Next]"/>
         </a>
       </xsl:when>
       <xsl:otherwise>
-        <img src="{$resource.root}../slides/img/transparent.gif" alt="[Next]"/>
+        <img src="{$resource.slide}img/transparent.gif" alt="[Next]"/>
       </xsl:otherwise>
     </xsl:choose>
   </div>


### PR DESCRIPTION
The way that $resource.root is used to include slide-specific resources is limiting and does not allow for easy use of local slide resources. For example, specifying the XSLT to use the local version of the slide css, js, and img is not possible.

This patch allows the user to specify a `resource.slide` parameter when generating the HTML or FO docbook5 slide outputs, which allows the generated HTML/FO to point to local slide resources.
- Declare a $resource.slide XSLT param with a default value of
  $resource.root; if $resource.slide is not defined, this change has no
  user impact
- The slide resources are included via their locality to the
  $resource.root. This limits the flexibility of pulling in external
  slide resources, especially when using the xslt20-resource repository
