### PR TITLE
Fix bug where callout.unicode causes error.

### DIFF
--- a/xslt/base/html/callouts.xsl
+++ b/xslt/base/html/callouts.xsl
@@ -114,7 +114,7 @@
            alt="{$iconum}" border="0"/>
     </xsl:when>
     <xsl:when test="$callout.unicode != 0
-                    and $iconum &lt;= $callout.unicode.number.limit">
+                    and $iconum &lt;= number($callout.unicode.number.limit)">
       <xsl:choose>
         <xsl:when test="$callout.unicode.start.character = 10102">
           <xsl:choose>


### PR DESCRIPTION
When callout.unicode=1, the the test to compare
callout.unicode.number.limit to the callout number
fails because callout.unicode.number.limit is a string.
