### PR TITLE
Work around a problem running the stylesheets in eXistDB.

### DIFF
--- a/xslt/base/common/l10n.xsl
+++ b/xslt/base/common/l10n.xsl
@@ -36,6 +36,10 @@
   <xsl:call-template name="t:user-localization-data"/>
 </xsl:variable>
 
+<xsl:variable name="localepath">
+  <xsl:value-of select="concat('../common/', $l10n.locale.dir)"/>
+</xsl:variable>
+
 <!-- ============================================================ -->
 
 <doc:template name="t:user-localization-data"
@@ -869,7 +873,7 @@ the English locale value will be used as the default.</para>
     </xsl:when>
     <xsl:otherwise>
       <xsl:sequence
-          select="doc-available(f:resolve-path(concat($lang,'.xml'), $l10n.locale.dir))"/>
+          select="doc-available(concat($localepath, $lang,'.xml'))"/>
     </xsl:otherwise>
   </xsl:choose>
 
@@ -946,8 +950,7 @@ the English locale value will be used as the default.</para>
                     select="mldb:load-locale($lang)"/>
     </xsl:when>
     <xsl:otherwise>
-      <xsl:variable name="locale-file"
-                    select="f:resolve-path(concat($lang,'.xml'), $l10n.locale.dir)"/>
+      <xsl:variable name="locale-file" select="concat($localepath, $lang,'.xml')"/>
       <xsl:sequence select="doc($locale-file)/l:l10n"/>
     </xsl:otherwise>
   </xsl:choose>


### PR DESCRIPTION
eXistDB doesn't allow saxon to resolve a value for absolute-uri-path() and so the stylesheets can't resolve the path to the locale files. For the time being we can just use a relative path to reference them, which works from the command line as well as in eXist.

Not sure what the proper solution would be, as clearly the locale path might be elsewhere. But, without such a fix it is not possible to include the docbook 5 stylesheets in an eXistDB app.

Suggestions gladly received.