### PR TITLE
ExistDB's parser doesn't like dynamic xml:id attribute values!

### DIFF
--- a/xslt/base/html/chunktemp.xsl
+++ b/xslt/base/html/chunktemp.xsl
@@ -27,31 +27,46 @@
   </xsl:template>
 
   <xsl:template match="/*" mode="m:identify-chunks" priority="100">
-    <chunk xml:id="{generate-id()}">
+    <chunk>
+      <xsl:attribute name="xml:id">
+        <xsl:value-of select="generate-id()"/>    
+      </xsl:attribute>
       <xsl:apply-templates select="*" mode="m:identify-chunks"/>
     </chunk>
   </xsl:template>
 
   <xsl:template match="db:book|db:part|db:reference|db:refentry" mode="m:identify-chunks">
-    <chunk xml:id="{generate-id()}">
+    <chunk>
+      <xsl:attribute name="xml:id">
+        <xsl:value-of select="generate-id()"/>    
+      </xsl:attribute>
       <xsl:apply-templates select="*" mode="m:identify-chunks"/>
     </chunk>
   </xsl:template>
 
   <xsl:template match="db:preface|db:chapter|db:appendix|db:colophon" mode="m:identify-chunks">
-    <chunk xml:id="{generate-id()}">
+    <chunk>
+      <xsl:attribute name="xml:id">
+        <xsl:value-of select="generate-id()"/>    
+      </xsl:attribute>
       <xsl:apply-templates select="*" mode="m:identify-chunks"/>
     </chunk>
   </xsl:template>
 
   <xsl:template match="db:book/db:bibliography|db:book/db:glossary" mode="m:identify-chunks">
-    <chunk xml:id="{generate-id()}">
+    <chunk>
+      <xsl:attribute name="xml:id">
+        <xsl:value-of select="generate-id()"/>    
+      </xsl:attribute>
       <xsl:apply-templates select="*" mode="m:identify-chunks"/>
     </chunk>
   </xsl:template>
 
   <xsl:template match="db:book/db:index|db:setindex" mode="m:identify-chunks">
-    <chunk xml:id="{generate-id()}">
+    <chunk>
+      <xsl:attribute name="xml:id">
+        <xsl:value-of select="generate-id()"/>    
+      </xsl:attribute>
       <xsl:apply-templates select="*" mode="m:identify-chunks"/>
     </chunk>
   </xsl:template>
@@ -60,7 +75,10 @@
     <xsl:choose>
       <xsl:when test="$chunk.section.depth &gt;= count(ancestor::db:section)+1 and 
 		      not(ancestor::*/processing-instruction('dbhtml')[normalize-space(.) = 'stop-chunking'])">
-	<chunk xml:id="{generate-id()}">
+	<chunk>
+          <xsl:attribute name="xml:id">
+            <xsl:value-of select="generate-id()"/>    
+          </xsl:attribute>
 	  <xsl:apply-templates select="*" mode="m:identify-chunks"/>
 	</chunk>
       </xsl:when>

--- a/xslt/base/html/verbatim-patch.xsl
+++ b/xslt/base/html/verbatim-patch.xsl
@@ -587,7 +587,11 @@ an element that has content.</para>
 </xsl:template>
 
 <xsl:template match="db:area" mode="mp:insert-callout">
-  <ghost:co number="{@ghost:number}" xml:id="{@xml:id}"/>
+  <ghost:co number="{@ghost:number}">
+    <xsl:attribute name="xml:id">
+      <xsl:value-of select="generate-id()"/>    
+    </xsl:attribute>
+  </ghost:co>
 </xsl:template>
 
 <!-- ============================================================ -->


### PR DESCRIPTION
Does the XSLT standard specify special handling of the xml:id attribute? The eXistDB database fails to load a stylesheet containing:

```
<element xml:id="{generate-id()}"/>
```

complaining with 

```
The XML parser reported a problem: Value of xml:id attribute is not a valid NCName: {generate-id()}
```

If instead we set the attribute with xsl:attribute the problem goes away.

This patch does that for all cases that attempt to set the xml:id directly from the xpath, and so allow the use of the stylesheets in eXistDB. Should be no-op in other environments. 
