### PR TITLE
Removed deploy stanza

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,14 +21,3 @@ env:
   - secure: L8BgolosqoP2Sp7oSaOh17MRtNo3s4WN2IV8000Ofk3BRX/fp1WFDtoxX3/2A2YKxq59rdD1OPQub01QzltR3vA/DP4s/9ITNJB/iSbDGPloVJz7EwuVRkm3nlgX8KroEIPepZc55AMfq0e61+JFu7hriyLS0IuO3fVe2j50eGo=
 after_success:
 - ".travis/publish-results.sh"
-deploy:
-  provider: releases
-  api_key:
-    secure: DABnpUe+E4lFb0ku+j8UhYPUCrfY6YvhYT2M7SL9o9rg+eUlmDDowJO9Mbaxldj0x1JANT2dvkMgzZcxo2VUAQjGgMy8V7JHWEikaOdmmcfngK+P+QqAy+3ytsMLGny6jV7pKJwLisZ9Gcb75REvC2I64n3l/mBhzTgE6kXVuyA=
-    secure: U++4g3Q+UFvRcE1RZx+jZXO1X8oOaUT6SWT2bvmBWV4P2wcDWKD/hhb0QnX4xONvgMt5f2ToRypDLPTjASr5ynl9IYaSk2blfg6h5GZ79d1EtbOjXBw0L6jgg+Gb0gSTJaIx9moN5QuK1MziFu4HqB1iWwNyMnVtJTk8KaN10bE=
-  file:
-    - build/distributions/docbook-xslt2-$TRAVIS_TAG.zip
-  skip_cleanup: true
-  on:
-    tags: true
-    all_branches: true


### PR DESCRIPTION
Apparently you can only have one API key in there so either docbook/ can be automatically deployed or ndw/ can be automatically deployed, but not both.

The other one errors out which is very inconvenient.

So no automatic deployments until I figure this out.
