### PR TITLE
Misc bug fixes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=2.0.19
+version=2.0.20
 snapshot=
 builtBy=Norman Walsh
 baseline=0

--- a/test/src/mediaobject.003.xml
+++ b/test/src/mediaobject.003.xml
@@ -1,0 +1,22 @@
+<article xmlns="http://docbook.org/ns/docbook" version="5.1">
+<title>Mediaobject test</title>
+
+<para>This tests passing multiple objects through to HTML using
+srcset.</para>
+
+  <mediaobject>
+    <imageobject>
+      <imagedata
+        fileref="../graphics/duck.png"
+        format="PNG">
+      </imagedata>
+      <imagedata
+        fileref="../graphics/duck-small.png"
+        format="PNG">
+      </imagedata>
+    </imageobject>
+    <textobject><phrase>The DocBook: TDG Duck</phrase></textobject>
+    <caption><para>The Duck</para></caption>
+  </mediaobject>
+
+</article>

--- a/vendor/marklogic/setup.sh
+++ b/vendor/marklogic/setup.sh
@@ -11,6 +11,7 @@ HOSTNAME=localhost
 LOCALE_DATABASE=1
 LOCALE_MODULES=1
 LOCALE_FILESYSTEM=1
+LOCALE_DIRECTORY=`dirname $0`/../../xslt/base/common/locales
 
 # Configure artifact names
 
@@ -130,7 +131,7 @@ API="http://$HOSTNAME:8000/v1/documents"
 CURLOPT="--anyauth -u $ADMIN_USER:$ADMIN_PASS"
 
 if [ $LOCALE_DATABASE = 1 ]; then
-for LOCALE in ../../xslt/base/common/locales/*.xml; do
+for LOCALE in $LOCALE_DIRECTORY/*.xml; do
     LANG=`basename $LOCALE .xml`
     echo "Uploading $LANG locale..."
     curl $CURLOPT $PUT --upload-file $LOCALE \

--- a/xslt/base/common/common.xsl
+++ b/xslt/base/common/common.xsl
@@ -880,9 +880,12 @@ object is recognized as a graphic.</para>
   <xsl:variable name="ext"
                 select="f:filename-extension($filename)"/>
 
-  <xsl:variable name="data" select="$object/db:videodata
-                                    |$object/db:imagedata
-                                    |$object/db:audiodata"/>
+  <!-- FIXME: Support multiple imagedata objects; see
+       https://github.com/docbook/docbook/issues/49 and
+       https://github.com/docbook/docbook/issues/52 -->
+  <xsl:variable name="data" select="($object/db:videodata
+                                     |$object/db:imagedata
+                                     |$object/db:audiodata)[1]"/>
 
   <xsl:variable name="explicit-format" select="lower-case($data/@format)"/>
 

--- a/xslt/base/fo/graphics.xsl
+++ b/xslt/base/fo/graphics.xsl
@@ -75,8 +75,11 @@
   </fo:block>
 </xsl:template>
 
+<!-- FIXME: Support multiple imagedata objects; see
+     https://github.com/docbook/docbook/issues/49 and
+     https://github.com/docbook/docbook/issues/52 -->
 <xsl:template match="db:imageobject">
-  <xsl:apply-templates select="db:imagedata"/>
+  <xsl:apply-templates select="db:imagedata[1]"/>
 </xsl:template>
 
 <xsl:template match="db:imagedata">

--- a/xslt/base/html/graphics.xsl
+++ b/xslt/base/html/graphics.xsl
@@ -925,7 +925,10 @@ valign: <xsl:value-of select="@valign"/></xsl:message>
       <xsl:apply-templates/>
     </xsl:when>
     <xsl:otherwise>
-      <xsl:apply-templates select="db:imagedata"/>
+      <!-- FIXME: Support multiple imagedata objects; see
+           https://github.com/docbook/docbook/issues/49 and
+           https://github.com/docbook/docbook/issues/52 -->
+      <xsl:apply-templates select="db:imagedata[1]"/>
     </xsl:otherwise>
   </xsl:choose>
 </xsl:template>

--- a/xslt/base/preprocess/50-normalize.xsl
+++ b/xslt/base/preprocess/50-normalize.xsl
@@ -1,12 +1,13 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:db="http://docbook.org/ns/docbook"
                 xmlns:doc="http://nwalsh.com/xsl/documentation/1.0"
+                xmlns:f="http://docbook.org/xslt/ns/extension"
                 xmlns:ghost="http://docbook.org/ns/docbook/ephemeral"
                 xmlns:m="http://docbook.org/xslt/ns/mode"
                 xmlns:mp="http://docbook.org/xslt/ns/mode/private"
                 xmlns:n="http://docbook.org/xslt/ns/normalize"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
-		exclude-result-prefixes="db doc ghost m mp n xs"
+		exclude-result-prefixes="db doc f ghost m mp n xs"
                 version="2.0">
 
 <xsl:import href="../common/functions.xsl"/>
@@ -448,7 +449,7 @@ if appropriate</refpurpose>
     </xsl:when>
     <xsl:otherwise>
       <xsl:value-of
-          select="unparsed-text(resolve-uri($data/@fileref, base-uri(.)))"/>
+          select="unparsed-text(f:resolve-path($data/@fileref, base-uri(.)))"/>
     </xsl:otherwise>
   </xsl:choose>
 </xsl:template>
@@ -465,7 +466,7 @@ if appropriate</refpurpose>
       <xsl:value-of select="unparsed-text(unparsed-entity-uri(db:textdata/@entityref))"/>
     </xsl:when>
     <xsl:otherwise>
-      <xsl:value-of select="unparsed-text(resolve-uri(db:textdata/@fileref, base-uri(.)))"/>
+      <xsl:value-of select="unparsed-text(f:resolve-path(db:textdata/@fileref, base-uri(.)))"/>
     </xsl:otherwise>
   </xsl:choose>
 </xsl:template>

--- a/xslt/base/xlink/xlinklb.xsl
+++ b/xslt/base/xlink/xlinklb.xsl
@@ -2,9 +2,13 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:db="http://docbook.org/ns/docbook"
+                xmlns:f="http://docbook.org/xslt/ns/extension"
                 xmlns="http://docbook.org/ns/docbook"
                 xmlns:xlink="http://www.w3.org/1999/xlink"
+                exclude-result-prefixes="f"
                 version="2.0">
+
+<xsl:import href="../common/functions.xsl"/>
 
 <xsl:output method="xml" indent="no"/>
 
@@ -36,7 +40,7 @@
   <xsl:variable name="lto" select="(../*[@xlink:type='locator' and @xlink:label=$to])[1]"/>
 
   <xsl:if test="$lfrom and $lto and $lfrom/@xlink:href=''">
-    <xsl:sequence select="doc(resolve-uri($lto/@xlink:href, base-uri($lto)))/*/*[@xlink:type='extended']"/>
+    <xsl:sequence select="doc(f:resolve-path($lto/@xlink:href, base-uri($lto)))/*/*[@xlink:type='extended']"/>
   </xsl:if>
 </xsl:template>
 


### PR DESCRIPTION
1. Handle the case where imageobject contains more than one imagedata
2. Use f:resolve-path to avoid problems with pedantic implementations of fn:resolve-uri
3. Make vendor/marklogic/setup.sh independent of the cwd