### PR TITLE
Minor bugfixes

### DIFF
--- a/xslt/base/common/olink.xsl
+++ b/xslt/base/common/olink.xsl
@@ -1020,7 +1020,7 @@
 
   <xsl:if test="not(starts-with(normalize-space($xrefstyle), 'select:') 
               and (contains($xrefstyle, 'docname')))
-              and ($olink.doctitle = 'yes' or $olink.doctitle = '1')
+              and ($olink.doctitle = 1)
               and $current.docid != '' 
               and $rootptr != $targetptr
               and $current.docid != $targetdoc

--- a/xslt/base/html/inlines.xsl
+++ b/xslt/base/html/inlines.xsl
@@ -691,8 +691,8 @@ and <tag>firstterm</tag> elements.</para>
 
 	<xsl:variable name="targets"
 		      select="//db:glossentry
-			        [normalize-space(db:glossterm) = $term
-			         or normalize-space(db:glossterm/@baseform)
+			        [db:glossterm/normalize-space(.) = $term
+			         or db:glossterm/normalize-space(@baseform)
 				    = $term]"/>
 
 	<xsl:variable name="target" select="$targets[1]"/>


### PR DESCRIPTION
- olink.doctitle expected to be string in one place
- Glossary handling failing a bit when more than one glossterm present (which is against schema, but allowed in other places in the stylesheets)
