### PR TITLE
Add support for side.region.precedence, flow into title pages, callouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@
 /test/cssprint-actual/
 /test/foprint-actual/
 /xslt/base/VERSION.xsl
+docbook-xslt2.xpr

--- a/xslt/base/fo/callout.xsl
+++ b/xslt/base/fo/callout.xsl
@@ -1,0 +1,236 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet exclude-result-prefixes="db f fn m t xlink xs" version="2.0" xmlns:db="http://docbook.org/ns/docbook" xmlns:f="http://docbook.org/xslt/ns/extension" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:fo="http://www.w3.org/1999/XSL/Format" xmlns:ghost="http://docbook.org/ns/docbook/ephemeral" xmlns:m="http://docbook.org/xslt/ns/mode" xmlns:t="http://docbook.org/xslt/ns/template" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+  <xsl:template match="db:co" mode="m:verbatim m:callout-bug">
+    <!-- pass addId=false() when processing callout links -->
+    <xsl:param name="addId" select="true()"/>
+    <xsl:call-template name="t:callout-bug">
+      <xsl:with-param name="db:conum">
+        <xsl:number count="db:co" format="1" from="db:programlisting | db:screen | db:literallayout | db:synopsis" level="any"/>
+      </xsl:with-param>
+      <xsl:with-param name="id">
+        <xsl:if test="$addId">
+          <xsl:value-of select="@xml:id"/>
+        </xsl:if>
+      </xsl:with-param>
+    </xsl:call-template>
+  </xsl:template>
+
+  <xsl:template match="db:calloutlist">
+    <fo:block text-align="{$alignment}">
+      <xsl:if test="db:title | db:info/db:title">
+        <xsl:apply-templates mode="list.title.mode" select="(db:title | db:info/db:title)[1]"/>
+      </xsl:if>
+      <fo:list-block xsl:use-attribute-sets="calloutlist.properties">
+        <xsl:apply-templates select="db:callout"/>
+      </fo:list-block>
+    </fo:block>
+  </xsl:template>
+
+  <xsl:template match="db:callout">
+    <fo:list-item xsl:use-attribute-sets="callout.properties">
+      <fo:list-item-label end-indent="label-end()">
+        <fo:block>
+          <xsl:call-template name="callout.arearefs">
+            <xsl:with-param name="arearefs" select="@arearefs"/>
+          </xsl:call-template>
+        </fo:block>
+      </fo:list-item-label>
+      <fo:list-item-body start-indent="body-start()">
+        <fo:block>
+          <xsl:apply-templates/>
+        </fo:block>
+      </fo:list-item-body>
+    </fo:list-item>
+  </xsl:template>
+
+  <xsl:template match="db:areaset" mode="conumber">
+    <xsl:number count="db:area | db:areaset" format="1"/>
+  </xsl:template>
+
+  <xsl:template match="db:area" mode="conumber">
+    <xsl:number count="db:area | db:areaset" format="1"/>
+  </xsl:template>
+
+  <xsl:template name="t:callout-bug">
+    <xsl:param name="db:conum" select="1"/>
+    <xsl:param name="id"/>
+    <xsl:choose>
+      <!-- Draw callouts as images -->
+      <xsl:when test="$callout.graphics != 0 and number($db:conum) le number($callout.graphics.number.limit)">
+        <xsl:variable name="filename" select="concat($callout.graphics.path, $db:conum, $callout.graphics.extension)"/>
+        <fo:external-graphic alignment-adjust="middle" alignment-baseline="central" content-width="{$callout.icon.size}" display-align="center" width="{$callout.icon.size}">
+          <xsl:attribute name="src">
+            <xsl:text>url(</xsl:text>
+            <xsl:value-of select="$filename"/>
+            <xsl:text>)</xsl:text>
+          </xsl:attribute>
+          <xsl:if test="$id != ''">
+            <xsl:attribute name="id" select="$id"/>
+          </xsl:if>
+        </fo:external-graphic>
+      </xsl:when>
+      <xsl:when test="$callout.unicode != 0 and number($db:conum) le number($callout.unicode.number.limit)">
+        <xsl:variable name="comarkup">
+          <xsl:choose>
+            <xsl:when test="$callout.unicode.start.character = 10102">
+              <xsl:choose>
+                <xsl:when test="$db:conum = 1">&#10102;</xsl:when>
+                <xsl:when test="$db:conum = 2">&#10103;</xsl:when>
+                <xsl:when test="$db:conum = 3">&#10104;</xsl:when>
+                <xsl:when test="$db:conum = 4">&#10105;</xsl:when>
+                <xsl:when test="$db:conum = 5">&#10106;</xsl:when>
+                <xsl:when test="$db:conum = 6">&#10107;</xsl:when>
+                <xsl:when test="$db:conum = 7">&#10108;</xsl:when>
+                <xsl:when test="$db:conum = 8">&#10109;</xsl:when>
+                <xsl:when test="$db:conum = 9">&#10110;</xsl:when>
+                <xsl:when test="$db:conum = 10">&#10111;</xsl:when>
+                <xsl:when test="$db:conum = 11">&#9451;</xsl:when>
+                <xsl:when test="$db:conum = 12">&#9452;</xsl:when>
+                <xsl:when test="$db:conum = 13">&#9453;</xsl:when>
+                <xsl:when test="$db:conum = 14">&#9454;</xsl:when>
+                <xsl:when test="$db:conum = 15">&#9455;</xsl:when>
+                <xsl:when test="$db:conum = 16">&#9456;</xsl:when>
+                <xsl:when test="$db:conum = 17">&#9457;</xsl:when>
+                <xsl:when test="$db:conum = 18">&#9458;</xsl:when>
+                <xsl:when test="$db:conum = 19">&#9459;</xsl:when>
+                <xsl:when test="$db:conum = 20">&#9460;</xsl:when>
+              </xsl:choose>
+            </xsl:when>
+            <xsl:when test="$callout.unicode.start.character = 9312">
+              <xsl:choose>
+                <xsl:when test="$db:conum = 1">&#9312;</xsl:when>
+                <xsl:when test="$db:conum = 2">&#9313;</xsl:when>
+                <xsl:when test="$db:conum = 3">&#9314;</xsl:when>
+                <xsl:when test="$db:conum = 4">&#9315;</xsl:when>
+                <xsl:when test="$db:conum = 5">&#9316;</xsl:when>
+                <xsl:when test="$db:conum = 6">&#9317;</xsl:when>
+                <xsl:when test="$db:conum = 7">&#9318;</xsl:when>
+                <xsl:when test="$db:conum = 8">&#9319;</xsl:when>
+                <xsl:when test="$db:conum = 9">&#9320;</xsl:when>
+                <xsl:when test="$db:conum = 10">&#9321;</xsl:when>
+                <xsl:when test="$db:conum = 11">&#9322;</xsl:when>
+                <xsl:when test="$db:conum = 12">&#9323;</xsl:when>
+                <xsl:when test="$db:conum = 13">&#9324;</xsl:when>
+                <xsl:when test="$db:conum = 14">&#9325;</xsl:when>
+                <xsl:when test="$db:conum = 15">&#9326;</xsl:when>
+                <xsl:when test="$db:conum = 16">&#9327;</xsl:when>
+                <xsl:when test="$db:conum = 17">&#9328;</xsl:when>
+                <xsl:when test="$db:conum = 18">&#9329;</xsl:when>
+                <xsl:when test="$db:conum = 19">&#9330;</xsl:when>
+                <xsl:when test="$db:conum = 20">&#9331;</xsl:when>
+              </xsl:choose>
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:message>
+                <xsl:text>Don't know how to generate Unicode callouts </xsl:text>
+                <xsl:text>when $callout.unicode.start.character is </xsl:text>
+                <xsl:value-of select="$callout.unicode.start.character"/>
+              </xsl:message>
+              <fo:inline background-color="#404040" baseline-shift="0.1em" color="white" font-family="{$body.fontset}" font-size="75%" font-weight="bold" padding-bottom="0.1em" padding-end="0.2em" padding-start="0.2em" padding-top="0.1em">
+                <xsl:if test="$id != ''">
+                  <xsl:attribute name="id" select="$id"/>
+                </xsl:if>
+                <xsl:value-of select="$db:conum"/>
+              </fo:inline>
+            </xsl:otherwise>
+          </xsl:choose>
+        </xsl:variable>
+        <xsl:choose>
+          <xsl:when test="$callout.unicode.font != ''">
+            <fo:inline font-family="{$callout.unicode.font}">
+              <xsl:if test="$id != ''">
+                <xsl:attribute name="id" select="$id"/>
+              </xsl:if>
+              <xsl:copy-of select="$comarkup"/>
+            </fo:inline>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:copy-of select="$comarkup"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <!-- Most safe: draw a dark gray square with a white number inside -->
+      <xsl:otherwise>
+        <fo:inline background-color="#404040" baseline-shift="0.1em" color="white" font-family="{$body.fontset}" font-size="75%" font-weight="bold" padding-bottom="0.1em" padding-end="0.2em" padding-start="0.2em" padding-top="0.1em">
+          <xsl:if test="$id != ''">
+            <xsl:attribute name="id" select="$id"/>
+          </xsl:if>
+          <xsl:value-of select="$db:conum"/>
+        </fo:inline>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <!-- recurse through rearefs -->
+  <xsl:template name="callout.arearefs">
+    <xsl:param name="arearefs"/>
+    <xsl:if test="$arearefs != ''">
+      <xsl:choose>
+        <xsl:when test="substring-before($arearefs, ' ') = ''">
+          <xsl:call-template name="callout.arearef">
+            <xsl:with-param name="arearef" select="$arearefs"/>
+          </xsl:call-template>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:call-template name="callout.arearef">
+            <xsl:with-param name="arearef" select="substring-before($arearefs, ' ')"/>
+          </xsl:call-template>
+        </xsl:otherwise>
+      </xsl:choose>
+      <xsl:call-template name="callout.arearefs">
+        <xsl:with-param name="arearefs" select="substring-after($arearefs, ' ')"/>
+      </xsl:call-template>
+    </xsl:if>
+  </xsl:template>
+
+  <xsl:template name="callout.arearef">
+    <xsl:param name="arearef"/>
+    <xsl:variable name="targets" select="key('id', $arearef)"/>
+    <xsl:variable name="target" select="$targets[1]"/>
+
+    <xsl:choose>
+      <xsl:when test="count($target) = 0">
+        <xsl:value-of select="$arearef"/>
+        <xsl:text>: ???</xsl:text>
+      </xsl:when>
+      <xsl:when test="local-name($target) = 'co'">
+        <fo:basic-link internal-destination="{$arearef}">
+          <xsl:apply-templates mode="m:callout-bug" select="$target">
+            <xsl:with-param name="addId" select="false()"/>
+          </xsl:apply-templates>
+        </fo:basic-link>
+      </xsl:when>
+      <xsl:when test="local-name($target) = 'areaset'">
+        <xsl:call-template name="t:callout-bug">
+          <xsl:with-param name="db:conum">
+            <xsl:apply-templates mode="conumber" select="$target"/>
+          </xsl:with-param>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:when test="local-name($target) = 'area'">
+        <xsl:choose>
+          <xsl:when test="$target/parent::db:areaset">
+            <xsl:call-template name="t:callout-bug">
+              <xsl:with-param name="db:conum">
+                <xsl:apply-templates mode="conumber" select="$target/parent::db:areaset"/>
+              </xsl:with-param>
+            </xsl:call-template>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:call-template name="t:callout-bug">
+              <xsl:with-param name="db:conum">
+                <xsl:apply-templates mode="conumber" select="$target"/>
+              </xsl:with-param>
+            </xsl:call-template>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:text>???</xsl:text>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/xslt/base/fo/pagesetup.xsl
+++ b/xslt/base/fo/pagesetup.xsl
@@ -2408,6 +2408,7 @@
     <xsl:when test="starts-with($master-reference, 'body') or
                     starts-with($master-reference, 'lot') or
                     starts-with($master-reference, 'front') or
+                    starts-with($master-reference, 'titlepage') or
                     $element = 'preface' or
 		    (starts-with($master-reference, 'back') and $element = 'appendix')">
       <xsl:attribute name="start-indent">
@@ -2662,6 +2663,7 @@
     <xsl:when test="starts-with($pageclass, 'body') or
                     starts-with($pageclass, 'lot') or
                     starts-with($pageclass, 'front') or
+                    starts-with($pageclass, 'titlepage') or
                     $element = 'preface' or
                     (starts-with($pageclass, 'back') and
                     $element = 'appendix')">

--- a/xslt/base/fo/pagesetup.xsl
+++ b/xslt/base/fo/pagesetup.xsl
@@ -58,6 +58,14 @@
   </xsl:choose>
 </xsl:param>
 
+<!-- should perhaps be select="not($side.region.precedence)" -->
+<xsl:param name="has.precedence">
+  <xsl:choose>
+    <xsl:when test="$side.region.precedence = 'true'">false</xsl:when>
+    <xsl:otherwise>true</xsl:otherwise>
+  </xsl:choose>
+</xsl:param>
+  
 <xsl:template name="t:setup-pagemasters">
   <fo:layout-master-set>
     <!-- blank pages -->
@@ -77,10 +85,20 @@
       </fo:region-body>
       <fo:region-before region-name="xsl-region-before-blank"
                         extent="{$region.before.extent}"
-                        display-align="before"/>
+                        display-align="before"
+                        precedence="{$has.precedence}"/>
       <fo:region-after region-name="xsl-region-after-blank"
                        extent="{$region.after.extent}"
-                        display-align="after"/>
+                        display-align="after"
+                        precedence="{$has.precedence}"/>
+        <xsl:call-template name="region.start">
+          <xsl:with-param name="sequence">blank</xsl:with-param>
+          <xsl:with-param name="pageclass">blank</xsl:with-param>
+        </xsl:call-template>
+        <xsl:call-template name="region.end">
+          <xsl:with-param name="sequence">blank</xsl:with-param>
+          <xsl:with-param name="pageclass">blank</xsl:with-param>
+        </xsl:call-template>
     </fo:simple-page-master>
 
     <!-- title pages -->
@@ -98,10 +116,20 @@
       </fo:region-body>
       <fo:region-before region-name="xsl-region-before-first"
                         extent="{$region.before.extent}"
-                        display-align="before"/>
+                        display-align="before"
+                        precedence="{$has.precedence}"/>
       <fo:region-after region-name="xsl-region-after-first"
                        extent="{$region.after.extent}"
-                        display-align="after"/>
+                        display-align="after"
+                        precedence="{$has.precedence}"/>
+        <xsl:call-template name="region.start">
+          <xsl:with-param name="sequence">first</xsl:with-param>
+          <xsl:with-param name="pageclass">titlepage</xsl:with-param>
+        </xsl:call-template>
+        <xsl:call-template name="region.end">
+          <xsl:with-param name="sequence">first</xsl:with-param>
+          <xsl:with-param name="pageclass">titlepage</xsl:with-param>
+        </xsl:call-template>
     </fo:simple-page-master>
 
     <fo:simple-page-master master-name="titlepage-odd"
@@ -118,10 +146,20 @@
       </fo:region-body>
       <fo:region-before region-name="xsl-region-before-odd"
                         extent="{$region.before.extent}"
-                        display-align="before"/>
+                        display-align="before"
+                        precedence="{$has.precedence}"/>
       <fo:region-after region-name="xsl-region-after-odd"
                        extent="{$region.after.extent}"
-                        display-align="after"/>
+                        display-align="after"
+                        precedence="{$has.precedence}"/>    
+        <xsl:call-template name="region.start">
+          <xsl:with-param name="sequence">odd</xsl:with-param>
+          <xsl:with-param name="pageclass">titlepage</xsl:with-param>
+        </xsl:call-template>
+        <xsl:call-template name="region.end">
+          <xsl:with-param name="sequence">odd</xsl:with-param>
+          <xsl:with-param name="pageclass">titlepage</xsl:with-param>
+        </xsl:call-template>
     </fo:simple-page-master>
 
     <fo:simple-page-master master-name="titlepage-even"
@@ -138,10 +176,20 @@
       </fo:region-body>
       <fo:region-before region-name="xsl-region-before-even"
                         extent="{$region.before.extent}"
-                        display-align="before"/>
+                        display-align="before"
+                        precedence="{$has.precedence}"/>
       <fo:region-after region-name="xsl-region-after-even"
                        extent="{$region.after.extent}"
-                        display-align="after"/>
+                        display-align="after"
+                        precedence="{$has.precedence}"/>    
+        <xsl:call-template name="region.start">
+          <xsl:with-param name="sequence">even</xsl:with-param>
+          <xsl:with-param name="pageclass">titlepage</xsl:with-param>
+        </xsl:call-template>
+        <xsl:call-template name="region.end">
+          <xsl:with-param name="sequence">even</xsl:with-param>
+          <xsl:with-param name="pageclass">titlepage</xsl:with-param>
+        </xsl:call-template>
     </fo:simple-page-master>
 
     <!-- list-of-title pages -->
@@ -159,10 +207,20 @@
       </fo:region-body>
       <fo:region-before region-name="xsl-region-before-first"
                         extent="{$region.before.extent}"
-                        display-align="before"/>
+                        display-align="before"
+                        precedence="{$has.precedence}"/>
       <fo:region-after region-name="xsl-region-after-first"
                        extent="{$region.after.extent}"
-                       display-align="after"/>
+                       display-align="after"
+                        precedence="{$has.precedence}"/>    
+        <xsl:call-template name="region.start">
+          <xsl:with-param name="sequence">first</xsl:with-param>
+          <xsl:with-param name="pageclass">lot</xsl:with-param>
+        </xsl:call-template>
+        <xsl:call-template name="region.end">
+          <xsl:with-param name="sequence">first</xsl:with-param>
+          <xsl:with-param name="pageclass">lot</xsl:with-param>
+        </xsl:call-template>
     </fo:simple-page-master>
 
     <fo:simple-page-master master-name="lot-odd"
@@ -179,10 +237,20 @@
       </fo:region-body>
       <fo:region-before region-name="xsl-region-before-odd"
                         extent="{$region.before.extent}"
-                        display-align="before"/>
+                        display-align="before"
+                        precedence="{$has.precedence}"/>
       <fo:region-after region-name="xsl-region-after-odd"
                        extent="{$region.after.extent}"
-                        display-align="after"/>
+                        display-align="after"
+                        precedence="{$has.precedence}"/>    
+        <xsl:call-template name="region.start">
+          <xsl:with-param name="sequence">odd</xsl:with-param>
+          <xsl:with-param name="pageclass">lot</xsl:with-param>
+        </xsl:call-template>
+        <xsl:call-template name="region.end">
+          <xsl:with-param name="sequence">odd</xsl:with-param>
+          <xsl:with-param name="pageclass">lot</xsl:with-param>
+        </xsl:call-template>
     </fo:simple-page-master>
 
     <fo:simple-page-master master-name="lot-even"
@@ -199,10 +267,20 @@
       </fo:region-body>
       <fo:region-before region-name="xsl-region-before-even"
                         extent="{$region.before.extent}"
-                        display-align="before"/>
+                        display-align="before"
+                        precedence="{$has.precedence}"/>
       <fo:region-after region-name="xsl-region-after-even"
                        extent="{$region.after.extent}"
-                        display-align="after"/>
+                        display-align="after"
+                        precedence="{$has.precedence}"/>    
+        <xsl:call-template name="region.start">
+          <xsl:with-param name="sequence">even</xsl:with-param>
+          <xsl:with-param name="pageclass">lot</xsl:with-param>
+        </xsl:call-template>
+        <xsl:call-template name="region.end">
+          <xsl:with-param name="sequence">even</xsl:with-param>
+          <xsl:with-param name="pageclass">lot</xsl:with-param>
+        </xsl:call-template>
     </fo:simple-page-master>
 
     <!-- frontmatter pages -->
@@ -220,10 +298,20 @@
       </fo:region-body>
       <fo:region-before region-name="xsl-region-before-first"
                         extent="{$region.before.extent}"
-                        display-align="before"/>
+                        display-align="before"
+                        precedence="{$has.precedence}"/>
       <fo:region-after region-name="xsl-region-after-first"
                        extent="{$region.after.extent}"
-                        display-align="after"/>
+                        display-align="after"
+                        precedence="{$has.precedence}"/>    
+        <xsl:call-template name="region.start">
+          <xsl:with-param name="sequence">first</xsl:with-param>
+          <xsl:with-param name="pageclass">front</xsl:with-param>
+        </xsl:call-template>
+        <xsl:call-template name="region.end">
+          <xsl:with-param name="sequence">first</xsl:with-param>
+          <xsl:with-param name="pageclass">front</xsl:with-param>
+        </xsl:call-template>
     </fo:simple-page-master>
 
     <fo:simple-page-master master-name="front-odd"
@@ -240,10 +328,20 @@
       </fo:region-body>
       <fo:region-before region-name="xsl-region-before-odd"
                         extent="{$region.before.extent}"
-                        display-align="before"/>
+                        display-align="before"
+                        precedence="{$has.precedence}"/>
       <fo:region-after region-name="xsl-region-after-odd"
                        extent="{$region.after.extent}"
-                        display-align="after"/>
+                        display-align="after"
+                        precedence="{$has.precedence}"/>    
+        <xsl:call-template name="region.start">
+          <xsl:with-param name="sequence">odd</xsl:with-param>
+          <xsl:with-param name="pageclass">front</xsl:with-param>
+        </xsl:call-template>
+        <xsl:call-template name="region.end">
+          <xsl:with-param name="sequence">odd</xsl:with-param>
+          <xsl:with-param name="pageclass">front</xsl:with-param>
+        </xsl:call-template>
     </fo:simple-page-master>
 
     <fo:simple-page-master master-name="front-even"
@@ -260,10 +358,20 @@
       </fo:region-body>
       <fo:region-before region-name="xsl-region-before-even"
                         extent="{$region.before.extent}"
-                        display-align="before"/>
+                        display-align="before"
+                        precedence="{$has.precedence}"/>
       <fo:region-after region-name="xsl-region-after-even"
                        extent="{$region.after.extent}"
-                        display-align="after"/>
+                        display-align="after"
+                        precedence="{$has.precedence}"/>    
+        <xsl:call-template name="region.start">
+          <xsl:with-param name="sequence">even</xsl:with-param>
+          <xsl:with-param name="pageclass">front</xsl:with-param>
+        </xsl:call-template>
+        <xsl:call-template name="region.end">
+          <xsl:with-param name="sequence">even</xsl:with-param>
+          <xsl:with-param name="pageclass">front</xsl:with-param>
+        </xsl:call-template>
     </fo:simple-page-master>
 
     <!-- body pages -->
@@ -281,10 +389,20 @@
       </fo:region-body>
       <fo:region-before region-name="xsl-region-before-first"
                         extent="{$region.before.extent}"
-                        display-align="before"/>
+                        display-align="before"
+                        precedence="{$has.precedence}"/>
       <fo:region-after region-name="xsl-region-after-first"
                        extent="{$region.after.extent}"
-                       display-align="after"/>
+                       display-align="after"
+                        precedence="{$has.precedence}"/>    
+        <xsl:call-template name="region.start">
+          <xsl:with-param name="sequence">first</xsl:with-param>
+          <xsl:with-param name="pageclass">body</xsl:with-param>
+        </xsl:call-template>
+        <xsl:call-template name="region.end">
+          <xsl:with-param name="sequence">first</xsl:with-param>
+          <xsl:with-param name="pageclass">body</xsl:with-param>
+        </xsl:call-template>
     </fo:simple-page-master>
 
     <fo:simple-page-master master-name="body-odd"
@@ -301,10 +419,20 @@
       </fo:region-body>
       <fo:region-before region-name="xsl-region-before-odd"
                         extent="{$region.before.extent}"
-                        display-align="before"/>
+                        display-align="before"
+                        precedence="{$has.precedence}"/>
       <fo:region-after region-name="xsl-region-after-odd"
                        extent="{$region.after.extent}"
-                       display-align="after"/>
+                       display-align="after"
+                        precedence="{$has.precedence}"/>    
+        <xsl:call-template name="region.start">
+          <xsl:with-param name="sequence">odd</xsl:with-param>
+          <xsl:with-param name="pageclass">body</xsl:with-param>
+        </xsl:call-template>
+        <xsl:call-template name="region.end">
+          <xsl:with-param name="sequence">odd</xsl:with-param>
+          <xsl:with-param name="pageclass">body</xsl:with-param>
+        </xsl:call-template>
     </fo:simple-page-master>
 
     <fo:simple-page-master master-name="body-even"
@@ -321,10 +449,20 @@
       </fo:region-body>
       <fo:region-before region-name="xsl-region-before-even"
                         extent="{$region.before.extent}"
-                        display-align="before"/>
+                        display-align="before"
+                        precedence="{$has.precedence}"/>
       <fo:region-after region-name="xsl-region-after-even"
                        extent="{$region.after.extent}"
-                       display-align="after"/>
+                       display-align="after"
+                        precedence="{$has.precedence}"/>    
+        <xsl:call-template name="region.start">
+          <xsl:with-param name="sequence">even</xsl:with-param>
+          <xsl:with-param name="pageclass">body</xsl:with-param>
+        </xsl:call-template>
+        <xsl:call-template name="region.end">
+          <xsl:with-param name="sequence">even</xsl:with-param>
+          <xsl:with-param name="pageclass">body</xsl:with-param>
+        </xsl:call-template>
     </fo:simple-page-master>
 
     <!-- backmatter pages -->
@@ -342,10 +480,20 @@
       </fo:region-body>
       <fo:region-before region-name="xsl-region-before-first"
                         extent="{$region.before.extent}"
-                        display-align="before"/>
+                        display-align="before"
+                        precedence="{$has.precedence}"/>
       <fo:region-after region-name="xsl-region-after-first"
                        extent="{$region.after.extent}"
-                       display-align="after"/>
+                       display-align="after"
+                        precedence="{$has.precedence}"/>    
+        <xsl:call-template name="region.start">
+          <xsl:with-param name="sequence">first</xsl:with-param>
+          <xsl:with-param name="pageclass">back</xsl:with-param>
+        </xsl:call-template>
+        <xsl:call-template name="region.end">
+          <xsl:with-param name="sequence">first</xsl:with-param>
+          <xsl:with-param name="pageclass">back</xsl:with-param>
+        </xsl:call-template>
     </fo:simple-page-master>
 
     <fo:simple-page-master master-name="back-odd"
@@ -362,10 +510,20 @@
       </fo:region-body>
       <fo:region-before region-name="xsl-region-before-odd"
                         extent="{$region.before.extent}"
-                        display-align="before"/>
+                        display-align="before"
+                        precedence="{$has.precedence}"/>
       <fo:region-after region-name="xsl-region-after-odd"
                        extent="{$region.after.extent}"
-                       display-align="after"/>
+                       display-align="after"
+                        precedence="{$has.precedence}"/>    
+        <xsl:call-template name="region.start">
+          <xsl:with-param name="sequence">odd</xsl:with-param>
+          <xsl:with-param name="pageclass">back</xsl:with-param>
+        </xsl:call-template>
+        <xsl:call-template name="region.end">
+          <xsl:with-param name="sequence">odd</xsl:with-param>
+          <xsl:with-param name="pageclass">back</xsl:with-param>
+        </xsl:call-template>
     </fo:simple-page-master>
 
     <fo:simple-page-master master-name="back-even"
@@ -382,10 +540,20 @@
       </fo:region-body>
       <fo:region-before region-name="xsl-region-before-even"
                         extent="{$region.before.extent}"
-                        display-align="before"/>
+                        display-align="before"
+                        precedence="{$has.precedence}"/>
       <fo:region-after region-name="xsl-region-after-even"
                        extent="{$region.after.extent}"
-                       display-align="after"/>
+                       display-align="after"
+                        precedence="{$has.precedence}"/>    
+        <xsl:call-template name="region.start">
+          <xsl:with-param name="sequence">even</xsl:with-param>
+          <xsl:with-param name="pageclass">back</xsl:with-param>
+        </xsl:call-template>
+        <xsl:call-template name="region.end">
+          <xsl:with-param name="sequence">even</xsl:with-param>
+          <xsl:with-param name="pageclass">back</xsl:with-param>
+        </xsl:call-template>
     </fo:simple-page-master>
 
     <!-- index pages -->
@@ -403,10 +571,20 @@
       </fo:region-body>
       <fo:region-before region-name="xsl-region-before-first"
                         extent="{$region.before.extent}"
-                        display-align="before"/>
+                        display-align="before"
+                        precedence="{$has.precedence}"/>
       <fo:region-after region-name="xsl-region-after-first"
                        extent="{$region.after.extent}"
-                       display-align="after"/>
+                       display-align="after"
+                        precedence="{$has.precedence}"/>    
+        <xsl:call-template name="region.start">
+          <xsl:with-param name="sequence">first</xsl:with-param>
+          <xsl:with-param name="pageclass">index</xsl:with-param>
+        </xsl:call-template>
+        <xsl:call-template name="region.end">
+          <xsl:with-param name="sequence">first</xsl:with-param>
+          <xsl:with-param name="pageclass">index</xsl:with-param>
+        </xsl:call-template>
     </fo:simple-page-master>
 
     <fo:simple-page-master master-name="index-odd"
@@ -423,10 +601,20 @@
       </fo:region-body>
       <fo:region-before region-name="xsl-region-before-odd"
                         extent="{$region.before.extent}"
-                        display-align="before"/>
+                        display-align="before"
+                        precedence="{$has.precedence}"/>
       <fo:region-after region-name="xsl-region-after-odd"
                        extent="{$region.after.extent}"
-                       display-align="after"/>
+                       display-align="after"
+                        precedence="{$has.precedence}"/>    
+        <xsl:call-template name="region.start">
+          <xsl:with-param name="sequence">odd</xsl:with-param>
+          <xsl:with-param name="pageclass">index</xsl:with-param>
+        </xsl:call-template>
+        <xsl:call-template name="region.end">
+          <xsl:with-param name="sequence">odd</xsl:with-param>
+          <xsl:with-param name="pageclass">index</xsl:with-param>
+        </xsl:call-template>
     </fo:simple-page-master>
 
     <fo:simple-page-master master-name="index-even"
@@ -443,10 +631,20 @@
       </fo:region-body>
       <fo:region-before region-name="xsl-region-before-even"
                         extent="{$region.before.extent}"
-                        display-align="before"/>
+                        display-align="before"
+                        precedence="{$has.precedence}"/>
       <fo:region-after region-name="xsl-region-after-even"
                        extent="{$region.after.extent}"
-                       display-align="after"/>
+                       display-align="after"
+                        precedence="{$has.precedence}"/>    
+        <xsl:call-template name="region.start">
+          <xsl:with-param name="sequence">even</xsl:with-param>
+          <xsl:with-param name="pageclass">index</xsl:with-param>
+        </xsl:call-template>
+        <xsl:call-template name="region.end">
+          <xsl:with-param name="sequence">even</xsl:with-param>
+          <xsl:with-param name="pageclass">index</xsl:with-param>
+        </xsl:call-template>
     </fo:simple-page-master>
 
     <xsl:if test="$draft.mode != 'no'">
@@ -470,11 +668,21 @@
         </fo:region-body>
         <fo:region-before region-name="xsl-region-before-blank"
                           extent="{$region.before.extent}"
-                          display-align="before"/>
+                          display-align="before"
+                        precedence="{$has.precedence}"/>
         <fo:region-after region-name="xsl-region-after-blank"
                          extent="{$region.after.extent}"
-                         display-align="after"/>
-      </fo:simple-page-master>
+                         display-align="after"
+                        precedence="{$has.precedence}"/>      
+        <xsl:call-template name="region.start">
+          <xsl:with-param name="sequence">blank</xsl:with-param>
+          <xsl:with-param name="pageclass">blank</xsl:with-param>
+        </xsl:call-template>
+        <xsl:call-template name="region.end">
+          <xsl:with-param name="sequence">blank</xsl:with-param>
+          <xsl:with-param name="pageclass">blank</xsl:with-param>
+        </xsl:call-template>
+    </fo:simple-page-master>
 
       <!-- draft title pages -->
       <fo:simple-page-master master-name="titlepage-first-draft"
@@ -498,11 +706,21 @@
         </fo:region-body>
         <fo:region-before region-name="xsl-region-before-first"
                           extent="{$region.before.extent}"
-                          display-align="before"/>
+                          display-align="before"
+                        precedence="{$has.precedence}"/>
         <fo:region-after region-name="xsl-region-after-first"
                          extent="{$region.after.extent}"
-                         display-align="after"/>
-      </fo:simple-page-master>
+                         display-align="after"
+                        precedence="{$has.precedence}"/>      
+        <xsl:call-template name="region.start">
+          <xsl:with-param name="sequence">first</xsl:with-param>
+          <xsl:with-param name="pageclass">titlepage</xsl:with-param>
+        </xsl:call-template>
+        <xsl:call-template name="region.end">
+          <xsl:with-param name="sequence">first</xsl:with-param>
+          <xsl:with-param name="pageclass">titlepage</xsl:with-param>
+        </xsl:call-template>
+    </fo:simple-page-master>
 
       <fo:simple-page-master master-name="titlepage-odd-draft"
                              page-width="{$page.width}"
@@ -525,11 +743,21 @@
         </fo:region-body>
         <fo:region-before region-name="xsl-region-before-odd"
                           extent="{$region.before.extent}"
-                          display-align="before"/>
+                          display-align="before"
+                        precedence="{$has.precedence}"/>
         <fo:region-after region-name="xsl-region-after-odd"
                          extent="{$region.after.extent}"
-                         display-align="after"/>
-      </fo:simple-page-master>
+                         display-align="after"
+                        precedence="{$has.precedence}"/>
+        <xsl:call-template name="region.start">
+          <xsl:with-param name="sequence">odd</xsl:with-param>
+          <xsl:with-param name="pageclass">titlepage</xsl:with-param>
+        </xsl:call-template>
+        <xsl:call-template name="region.end">
+          <xsl:with-param name="sequence">odd</xsl:with-param>
+          <xsl:with-param name="pageclass">titlepage</xsl:with-param>
+        </xsl:call-template>
+    </fo:simple-page-master>
 
       <fo:simple-page-master master-name="titlepage-even-draft"
                              page-width="{$page.width}"
@@ -552,11 +780,21 @@
         </fo:region-body>
         <fo:region-before region-name="xsl-region-before-even"
                           extent="{$region.before.extent}"
-                          display-align="before"/>
+                          display-align="before"
+                        precedence="{$has.precedence}"/>
         <fo:region-after region-name="xsl-region-after-even"
                          extent="{$region.after.extent}"
-                         display-align="after"/>
-      </fo:simple-page-master>
+                         display-align="after"
+                        precedence="{$has.precedence}"/>      
+        <xsl:call-template name="region.start">
+          <xsl:with-param name="sequence">even</xsl:with-param>
+          <xsl:with-param name="pageclass">titlepage</xsl:with-param>
+        </xsl:call-template>
+        <xsl:call-template name="region.end">
+          <xsl:with-param name="sequence">even</xsl:with-param>
+          <xsl:with-param name="pageclass">titlepage</xsl:with-param>
+        </xsl:call-template>
+    </fo:simple-page-master>
 
       <!-- draft list-of-title pages -->
       <fo:simple-page-master master-name="lot-first-draft"
@@ -580,11 +818,21 @@
         </fo:region-body>
         <fo:region-before region-name="xsl-region-before-first"
                           extent="{$region.before.extent}"
-                          display-align="before"/>
+                          display-align="before"
+                        precedence="{$has.precedence}"/>
         <fo:region-after region-name="xsl-region-after-first"
                          extent="{$region.after.extent}"
-                         display-align="after"/>
-      </fo:simple-page-master>
+                         display-align="after"
+                        precedence="{$has.precedence}"/>      
+        <xsl:call-template name="region.start">
+          <xsl:with-param name="sequence">first</xsl:with-param>
+          <xsl:with-param name="pageclass">lot</xsl:with-param>
+        </xsl:call-template>
+        <xsl:call-template name="region.end">
+          <xsl:with-param name="sequence">first</xsl:with-param>
+          <xsl:with-param name="pageclass">lot</xsl:with-param>
+        </xsl:call-template>
+    </fo:simple-page-master>
 
       <fo:simple-page-master master-name="lot-odd-draft"
                              page-width="{$page.width}"
@@ -607,11 +855,21 @@
         </fo:region-body>
         <fo:region-before region-name="xsl-region-before-odd"
                           extent="{$region.before.extent}"
-                          display-align="before"/>
+                          display-align="before"
+                        precedence="{$has.precedence}"/>
         <fo:region-after region-name="xsl-region-after-odd"
                          extent="{$region.after.extent}"
-                         display-align="after"/>
-      </fo:simple-page-master>
+                         display-align="after"
+                        precedence="{$has.precedence}"/>      
+        <xsl:call-template name="region.start">
+          <xsl:with-param name="sequence">odd</xsl:with-param>
+          <xsl:with-param name="pageclass">lot</xsl:with-param>
+        </xsl:call-template>
+        <xsl:call-template name="region.end">
+          <xsl:with-param name="sequence">odd</xsl:with-param>
+          <xsl:with-param name="pageclass">lot</xsl:with-param>
+        </xsl:call-template>
+    </fo:simple-page-master>
 
       <fo:simple-page-master master-name="lot-even-draft"
                              page-width="{$page.width}"
@@ -634,11 +892,21 @@
         </fo:region-body>
         <fo:region-before region-name="xsl-region-before-even"
                           extent="{$region.before.extent}"
-                          display-align="before"/>
+                          display-align="before"
+                        precedence="{$has.precedence}"/>
         <fo:region-after region-name="xsl-region-after-even"
                          extent="{$region.after.extent}"
-                         display-align="after"/>
-      </fo:simple-page-master>
+                         display-align="after"
+                        precedence="{$has.precedence}"/>    
+        <xsl:call-template name="region.start">
+          <xsl:with-param name="sequence">even</xsl:with-param>
+          <xsl:with-param name="pageclass">lot</xsl:with-param>
+        </xsl:call-template>
+        <xsl:call-template name="region.end">
+          <xsl:with-param name="sequence">even</xsl:with-param>
+          <xsl:with-param name="pageclass">lot</xsl:with-param>
+        </xsl:call-template>
+    </fo:simple-page-master>
 
       <!-- draft frontmatter pages -->
       <fo:simple-page-master master-name="front-first-draft"
@@ -662,11 +930,21 @@
         </fo:region-body>
         <fo:region-before region-name="xsl-region-before-first"
                           extent="{$region.before.extent}"
-                          display-align="before"/>
+                          display-align="before"
+                        precedence="{$has.precedence}"/>
         <fo:region-after region-name="xsl-region-after-first"
                          extent="{$region.after.extent}"
-                         display-align="after"/>
-      </fo:simple-page-master>
+                         display-align="after"
+                        precedence="{$has.precedence}"/>    
+        <xsl:call-template name="region.start">
+          <xsl:with-param name="sequence">first</xsl:with-param>
+          <xsl:with-param name="pageclass">front</xsl:with-param>
+        </xsl:call-template>
+        <xsl:call-template name="region.end">
+          <xsl:with-param name="sequence">first</xsl:with-param>
+          <xsl:with-param name="pageclass">front</xsl:with-param>
+        </xsl:call-template>
+    </fo:simple-page-master>
 
       <fo:simple-page-master master-name="front-odd-draft"
                              page-width="{$page.width}"
@@ -689,11 +967,21 @@
         </fo:region-body>
         <fo:region-before region-name="xsl-region-before-odd"
                           extent="{$region.before.extent}"
-                          display-align="before"/>
+                          display-align="before"
+                        precedence="{$has.precedence}"/>
         <fo:region-after region-name="xsl-region-after-odd"
                          extent="{$region.after.extent}"
-                         display-align="after"/>
-      </fo:simple-page-master>
+                         display-align="after"
+                        precedence="{$has.precedence}"/>    
+        <xsl:call-template name="region.start">
+          <xsl:with-param name="sequence">odd</xsl:with-param>
+          <xsl:with-param name="pageclass">front</xsl:with-param>
+        </xsl:call-template>
+        <xsl:call-template name="region.end">
+          <xsl:with-param name="sequence">odd</xsl:with-param>
+          <xsl:with-param name="pageclass">front</xsl:with-param>
+        </xsl:call-template>
+    </fo:simple-page-master>
 
       <fo:simple-page-master master-name="front-even-draft"
                              page-width="{$page.width}"
@@ -716,11 +1004,21 @@
         </fo:region-body>
         <fo:region-before region-name="xsl-region-before-even"
                           extent="{$region.before.extent}"
-                          display-align="before"/>
+                          display-align="before"
+                        precedence="{$has.precedence}"/>
         <fo:region-after region-name="xsl-region-after-even"
                          extent="{$region.after.extent}"
-                         display-align="after"/>
-      </fo:simple-page-master>
+                         display-align="after"
+                        precedence="{$has.precedence}"/>    
+        <xsl:call-template name="region.start">
+          <xsl:with-param name="sequence">even</xsl:with-param>
+          <xsl:with-param name="pageclass">front</xsl:with-param>
+        </xsl:call-template>
+        <xsl:call-template name="region.end">
+          <xsl:with-param name="sequence">even</xsl:with-param>
+          <xsl:with-param name="pageclass">front</xsl:with-param>
+        </xsl:call-template>
+    </fo:simple-page-master>
 
       <!-- draft body pages -->
       <fo:simple-page-master master-name="body-first-draft"
@@ -744,11 +1042,21 @@
         </fo:region-body>
         <fo:region-before region-name="xsl-region-before-first"
                           extent="{$region.before.extent}"
-                          display-align="before"/>
+                          display-align="before"
+                        precedence="{$has.precedence}"/>
         <fo:region-after region-name="xsl-region-after-first"
                          extent="{$region.after.extent}"
-                         display-align="after"/>
-      </fo:simple-page-master>
+                         display-align="after"
+                        precedence="{$has.precedence}"/>    
+        <xsl:call-template name="region.start">
+          <xsl:with-param name="sequence">first</xsl:with-param>
+          <xsl:with-param name="pageclass">body</xsl:with-param>
+        </xsl:call-template>
+        <xsl:call-template name="region.end">
+          <xsl:with-param name="sequence">first</xsl:with-param>
+          <xsl:with-param name="pageclass">body</xsl:with-param>
+        </xsl:call-template>
+    </fo:simple-page-master>
 
       <fo:simple-page-master master-name="body-odd-draft"
                              page-width="{$page.width}"
@@ -771,11 +1079,21 @@
         </fo:region-body>
         <fo:region-before region-name="xsl-region-before-odd"
                           extent="{$region.before.extent}"
-                          display-align="before"/>
+                          display-align="before"
+                        precedence="{$has.precedence}"/>
         <fo:region-after region-name="xsl-region-after-odd"
                          extent="{$region.after.extent}"
-                         display-align="after"/>
-      </fo:simple-page-master>
+                         display-align="after"
+                        precedence="{$has.precedence}"/>    
+        <xsl:call-template name="region.start">
+          <xsl:with-param name="sequence">odd</xsl:with-param>
+          <xsl:with-param name="pageclass">body</xsl:with-param>
+        </xsl:call-template>
+        <xsl:call-template name="region.end">
+          <xsl:with-param name="sequence">odd</xsl:with-param>
+          <xsl:with-param name="pageclass">body</xsl:with-param>
+        </xsl:call-template>
+    </fo:simple-page-master>
 
       <fo:simple-page-master master-name="body-even-draft"
                              page-width="{$page.width}"
@@ -798,11 +1116,21 @@
         </fo:region-body>
         <fo:region-before region-name="xsl-region-before-even"
                           extent="{$region.before.extent}"
-                          display-align="before"/>
+                          display-align="before"
+                        precedence="{$has.precedence}"/>
         <fo:region-after region-name="xsl-region-after-even"
                          extent="{$region.after.extent}"
-                         display-align="after"/>
-      </fo:simple-page-master>
+                         display-align="after"
+                        precedence="{$has.precedence}"/>    
+        <xsl:call-template name="region.start">
+          <xsl:with-param name="sequence">even</xsl:with-param>
+          <xsl:with-param name="pageclass">body</xsl:with-param>
+        </xsl:call-template>
+        <xsl:call-template name="region.end">
+          <xsl:with-param name="sequence">even</xsl:with-param>
+          <xsl:with-param name="pageclass">body</xsl:with-param>
+        </xsl:call-template>
+    </fo:simple-page-master>
 
       <!-- draft backmatter pages -->
       <fo:simple-page-master master-name="back-first-draft"
@@ -826,11 +1154,21 @@
         </fo:region-body>
         <fo:region-before region-name="xsl-region-before-first"
                           extent="{$region.before.extent}"
-                          display-align="before"/>
+                          display-align="before"
+                        precedence="{$has.precedence}"/>
         <fo:region-after region-name="xsl-region-after-first"
                          extent="{$region.after.extent}"
-                         display-align="after"/>
-      </fo:simple-page-master>
+                         display-align="after"
+                        precedence="{$has.precedence}"/>    
+        <xsl:call-template name="region.start">
+          <xsl:with-param name="sequence">first</xsl:with-param>
+          <xsl:with-param name="pageclass">back</xsl:with-param>
+        </xsl:call-template>
+        <xsl:call-template name="region.end">
+          <xsl:with-param name="sequence">first</xsl:with-param>
+          <xsl:with-param name="pageclass">back</xsl:with-param>
+        </xsl:call-template>
+    </fo:simple-page-master>
 
       <fo:simple-page-master master-name="back-odd-draft"
                              page-width="{$page.width}"
@@ -853,11 +1191,21 @@
         </fo:region-body>
         <fo:region-before region-name="xsl-region-before-odd"
                           extent="{$region.before.extent}"
-                          display-align="before"/>
+                          display-align="before"
+                        precedence="{$has.precedence}"/>
         <fo:region-after region-name="xsl-region-after-odd"
                          extent="{$region.after.extent}"
-                         display-align="after"/>
-      </fo:simple-page-master>
+                         display-align="after"
+                        precedence="{$has.precedence}"/>    
+        <xsl:call-template name="region.start">
+          <xsl:with-param name="sequence">odd</xsl:with-param>
+          <xsl:with-param name="pageclass">back</xsl:with-param>
+        </xsl:call-template>
+        <xsl:call-template name="region.end">
+          <xsl:with-param name="sequence">odd</xsl:with-param>
+          <xsl:with-param name="pageclass">back</xsl:with-param>
+        </xsl:call-template>
+    </fo:simple-page-master>
 
       <fo:simple-page-master master-name="back-even-draft"
                              page-width="{$page.width}"
@@ -880,11 +1228,21 @@
         </fo:region-body>
         <fo:region-before region-name="xsl-region-before-even"
                           extent="{$region.before.extent}"
-                          display-align="before"/>
+                          display-align="before"
+                        precedence="{$has.precedence}"/>
         <fo:region-after region-name="xsl-region-after-even"
                          extent="{$region.after.extent}"
-                         display-align="after"/>
-      </fo:simple-page-master>
+                         display-align="after"
+                        precedence="{$has.precedence}"/>    
+        <xsl:call-template name="region.start">
+          <xsl:with-param name="sequence">even</xsl:with-param>
+          <xsl:with-param name="pageclass">back</xsl:with-param>
+        </xsl:call-template>
+        <xsl:call-template name="region.end">
+          <xsl:with-param name="sequence">even</xsl:with-param>
+          <xsl:with-param name="pageclass">back</xsl:with-param>
+        </xsl:call-template>
+    </fo:simple-page-master>
 
       <!-- draft index pages -->
       <fo:simple-page-master master-name="index-first-draft"
@@ -908,11 +1266,21 @@
         </fo:region-body>
         <fo:region-before region-name="xsl-region-before-first"
                           extent="{$region.before.extent}"
-                          display-align="before"/>
+                          display-align="before"
+                        precedence="{$has.precedence}"/>
         <fo:region-after region-name="xsl-region-after-first"
                          extent="{$region.after.extent}"
-                         display-align="after"/>
-      </fo:simple-page-master>
+                         display-align="after"
+                        precedence="{$has.precedence}"/>    
+        <xsl:call-template name="region.start">
+          <xsl:with-param name="sequence">first</xsl:with-param>
+          <xsl:with-param name="pageclass">index</xsl:with-param>
+        </xsl:call-template>
+        <xsl:call-template name="region.end">
+          <xsl:with-param name="sequence">first</xsl:with-param>
+          <xsl:with-param name="pageclass">index</xsl:with-param>
+        </xsl:call-template>
+    </fo:simple-page-master>
 
       <fo:simple-page-master master-name="index-odd-draft"
                              page-width="{$page.width}"
@@ -935,11 +1303,21 @@
         </fo:region-body>
         <fo:region-before region-name="xsl-region-before-odd"
                           extent="{$region.before.extent}"
-                          display-align="before"/>
+                          display-align="before"
+                        precedence="{$has.precedence}"/>
         <fo:region-after region-name="xsl-region-after-odd"
                          extent="{$region.after.extent}"
-                         display-align="after"/>
-      </fo:simple-page-master>
+                         display-align="after"
+                        precedence="{$has.precedence}"/>    
+        <xsl:call-template name="region.start">
+          <xsl:with-param name="sequence">odd</xsl:with-param>
+          <xsl:with-param name="pageclass">index</xsl:with-param>
+        </xsl:call-template>
+        <xsl:call-template name="region.end">
+          <xsl:with-param name="sequence">odd</xsl:with-param>
+          <xsl:with-param name="pageclass">index</xsl:with-param>
+        </xsl:call-template>
+    </fo:simple-page-master>
 
       <fo:simple-page-master master-name="index-even-draft"
                              page-width="{$page.width}"
@@ -962,11 +1340,21 @@
         </fo:region-body>
         <fo:region-before region-name="xsl-region-before-even"
                           extent="{$region.before.extent}"
-                          display-align="before"/>
+                          display-align="before"
+                        precedence="{$has.precedence}"/>
         <fo:region-after region-name="xsl-region-after-even"
                          extent="{$region.after.extent}"
-                         display-align="after"/>
-      </fo:simple-page-master>
+                         display-align="after"
+                        precedence="{$has.precedence}"/>    
+        <xsl:call-template name="region.start">
+          <xsl:with-param name="sequence">even</xsl:with-param>
+          <xsl:with-param name="pageclass">index</xsl:with-param>
+        </xsl:call-template>
+        <xsl:call-template name="region.end">
+          <xsl:with-param name="sequence">even</xsl:with-param>
+          <xsl:with-param name="pageclass">index</xsl:with-param>
+        </xsl:call-template>
+    </fo:simple-page-master>
     </xsl:if>
 
     <!-- setup for title page(s) -->
@@ -2287,4 +2675,69 @@
   </xsl:choose>
 </xsl:template>
 
+
+  <!-- ==================================================================== -->
+  
+  <!-- Customize this template for custom side regions -->
+  <xsl:template name="region.start">
+    <xsl:param name="sequence">blank</xsl:param>
+    <xsl:param name="pageclass">blank</xsl:param>
+    
+    <xsl:choose>
+      <xsl:when test="$sequence = 'first' or $sequence = 'odd'">
+        <fo:region-start xsl:use-attribute-sets="region.inner.properties">
+          <xsl:attribute name="region-name">
+            <xsl:text>xsl-region-inner-</xsl:text>
+            <xsl:value-of select="$sequence"/>
+          </xsl:attribute>
+          <xsl:attribute name="extent">
+            <xsl:value-of select="$region.inner.extent"/>
+          </xsl:attribute>
+        </fo:region-start>
+      </xsl:when>
+      <xsl:otherwise>
+        <fo:region-start xsl:use-attribute-sets="region.outer.properties">
+          <xsl:attribute name="region-name">
+            <xsl:text>xsl-region-outer-</xsl:text>
+            <xsl:value-of select="$sequence"/>
+          </xsl:attribute>
+          <xsl:attribute name="extent">
+            <xsl:value-of select="$region.outer.extent"/>
+          </xsl:attribute>
+        </fo:region-start>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+  
+  <!-- Customize this template for custom side regions -->
+  <xsl:template name="region.end">
+    <xsl:param name="sequence">blank</xsl:param>
+    <xsl:param name="pageclass">blank</xsl:param>
+    
+    <xsl:choose>
+      <xsl:when test="$sequence = 'first' or $sequence = 'odd'">
+        <fo:region-end xsl:use-attribute-sets="region.outer.properties">
+          <xsl:attribute name="region-name">
+            <xsl:text>xsl-region-outer-</xsl:text>
+            <xsl:value-of select="$sequence"/>
+          </xsl:attribute>
+          <xsl:attribute name="extent">
+            <xsl:value-of select="$region.outer.extent"/>
+          </xsl:attribute>
+        </fo:region-end>
+      </xsl:when>
+      <xsl:otherwise>
+        <fo:region-end xsl:use-attribute-sets="region.inner.properties">
+          <xsl:attribute name="region-name">
+            <xsl:text>xsl-region-inner-</xsl:text>
+            <xsl:value-of select="$sequence"/>
+          </xsl:attribute>
+          <xsl:attribute name="extent">
+            <xsl:value-of select="$region.inner.extent"/>
+          </xsl:attribute>
+        </fo:region-end>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+  
 </xsl:stylesheet>

--- a/xslt/base/fo/param.xml
+++ b/xslt/base/fo/param.xml
@@ -1,5 +1,5 @@
 <article xmlns="http://docbook.org/ns/docbook">
-<title>HTML Parameters</title>
+<title>FO Parameters</title>
 
 <para>This should be expanded to do a better job of documentation.
 It's just a bogus mess right now.</para>
@@ -177,7 +177,8 @@ It's just a bogus mess right now.</para>
 <refentry xml:id="headers.on.blank.pages"/>
 <refentry xml:id="region.after.extent"/>
 <refentry xml:id="region.before.extent"/>
-
+<refentry xml:id="side.region.precedence"/>
+    
 <refentry xml:id="fo.processor"/>
 <refentry xml:id="root.properties"/>
 <refentry xml:id="alignment"/>

--- a/xslt/params/side.region.precedence.xml
+++ b/xslt/params/side.region.precedence.xml
@@ -1,0 +1,23 @@
+<refentry version="5.0" xml:id="show.comments" xmlns="http://docbook.org/ns/docbook" xmlns:src="http://nwalsh.com/xmlns/litprog/fragment" xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+    <refmeta>
+        <refentrytitle>side.region.precedence</refentrytitle>
+        <refmiscinfo role="type">boolean</refmiscinfo>
+    </refmeta>
+    <refnamediv>
+        <refname>side.region.precedence</refname>
+        <refpurpose>Determines side region page layout precedence.</refpurpose>
+    </refnamediv>
+    <refsynopsisdiv>
+        <src:fragment xml:id="side.region.precedence.frag">
+            <xsl:param name="side.region.precedence">false</xsl:param>
+        </src:fragment>
+    </refsynopsisdiv>
+    <refsect1>
+        <title>Description</title>
+        <para>If optional side regions on a page are established using parameters such as <parameter>body.margin.inner</parameter>, <parameter>region.inner.extent</parameter>, etc., then this parameter determines what happens at the corners where the side regions meet the header and footer regions.</para>
+        <para>If the value of this parameter is true, then the side regions have precedence and extend higher and lower, while the header and footer regions are narrower and fit inside the side regions.</para>
+        <para>If the value of this parameter is false (the default value), then the header and footer regions have precedence and extend over and below the side regions. Any value other than true or false is taken to be false.</para>
+        <para>See also <parameter>region.inner.extent</parameter>, <parameter>region.outer.extent</parameter>, <parameter>body.margin.inner</parameter>, <parameter>body.margin.outer</parameter>.</para>
+    </refsect1>
+</refentry>


### PR DESCRIPTION
Adds support for callouts in verbatim text.
Adds side.region.precedence support, allowing before- and after-regions to span the page width.
Adds titlepage class to fo:flow templates.
Adds an oXygen project file to .gitignore (I can't see how to remove it from the pull request.) 

Note that lines near ~94, ~677 should be checked regarding value for "sequence" — currently set to "blank" but perhaps should be empty or "odd"?
