### PR TITLE
Automatically publish tagged releases to CDN

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: java
 script: gradle dist
 sudo: false
 
+after_success: .travis/publish-release.sh
+
 deploy:
   provider: releases
   api_key:

--- a/.travis/generate_index.py
+++ b/.travis/generate_index.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+#
+# github pages allow directories to be navigated only if
+# they contain an index.html file.
+# This script traverses a directory tree starting at 'root',
+# generating 'index.html' files with file (and directory) listings,
+# unless the given directory already contains an 'index.html' file.
+
+import os
+from os.path import *
+import sys
+import datetime
+
+if len(sys.argv) != 2:
+    print('Usage: {} <root-directory>'.format(sys.argv[0]))
+    sys.exit(-1)
+
+# start the traversal here...
+root = abspath(sys.argv[1])
+# ...but print direcory names based on one level up (to include 'xsl/' etc.)
+base = dirname(root)
+
+def make_index(dir, dirs, files):
+    filename = join(dir, 'index.html')
+    if exists(filename):
+        return
+    with open(filename, 'w') as output:
+        output.write("""<html><head>
+<title>Index of {name}</title>
+<style>
+table {{ width: 100%; font-family: monospace;}}
+td {{ text-align: right}}
+td:first-child {{ text-align: left}}
+td:last-child {{ text-align: center}}
+</style>
+</head>
+<body><h1>{name}</h1>
+<table>""".format(name=relpath(dir, base)))
+        output.write('<tr><th>{}</th><th>{}</th><th>{}</th></tr>'.format("Name", "Size", "Last Modified"))
+        output.write('<tr><td><a href="..">..</a>/</td><td></td><td></td></tr>')
+        for d in dirs:
+            s = os.stat(join(dir, d))
+            format = '<tr><td><a href="{}">{}</a>/</td><td></td><td>{}</td></tr>'
+            output.write(format.format(d, d, datetime.datetime.fromtimestamp(int(s.st_mtime))))
+        for f in files:
+            s = os.stat(join(dir, f))
+            if s.st_size > 1073741824:
+                size = '{} GB'.format(s.st_size / 1073741824)
+            elif s.st_size > 1048576:
+                size = '{} MB'.format(s.st_size / 1048576)
+            elif s.st_size > 1024:
+                size = '{} KB'.format(s.st_size / 1024)
+            else:
+                size = '{} &nbsp;&nbsp;'.format(s.st_size)
+            format = '<tr><td><a href="{}">{}</a></td><td>{}</td><td>{}</td></tr>'
+            output.write(format.format(f, f, size, datetime.datetime.fromtimestamp(int(s.st_mtime))))
+        output.write("""</table>
+</body>
+</html>""")
+
+def process(dir):
+    all = os.listdir(dir)
+    dirs = sorted([d for d in all if isdir(join(dir, d))])
+    files = sorted([f for f in all if isfile(join(dir, f)) if f != 'index.html'])
+    make_index(dir, dirs, files)
+    # recurse into subdirectory, skipping links (such as 'current')
+    for d in dirs:
+        if not islink(join(dir, d)):
+            process(join(dir, d))
+
+process(root)

--- a/.travis/publish-release.sh
+++ b/.travis/publish-release.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -e # Exit with nonzero exit code if anything fails
+set -x # Show me what's going on
+here=$(dirname "${BASH_SOURCE[0]}")
+# Only commits to master should trigger deployment
+# (add 'travis' for testing purposes.)
+
+# debugging things
+#set | grep TRAVIS
+#pwd
+#whoami
+
+VERSION=`grep "^version=" < gradle.properties | cut -f2 -d=`
+
+if [ "$TRAVIS_PULL_REQUEST" != "false" ] || \
+   [ "$TRAVIS_BRANCH" != master -a "$TRAVIS_BRANCH" != travis ]; then
+    echo "Skipping deployment"
+    exit 0
+fi
+
+# Remember the SHA of the current build.
+SHA=$(git rev-parse --verify HEAD)
+
+# Clone the minimum of the CDN repo needed.
+CDN_REPO="https://$GH_TOKEN@github.com/docbook/cdn.git"
+git clone $CDN_REPO cdn --depth=1 -q
+
+# Clean out existing content...
+rm -rf cdn/release/xsl20/$VERSION
+
+# ...and copy the new one.
+cd cdn/release/xsl20
+unzip -q ../../../build/distributions/docbook-xslt2-$VERSION.zip
+mv docbook-xslt2-$VERSION $VERSION
+cd ../../..
+
+# We could normally make "current" symbolic links to "snapshot"
+# but github's policy doesn't allow to publish symbolic links in pages.
+rm -rf cdn/release/xsl20/current
+mkdir -p cdn/release/xsl20/current
+cp -a cdn/release/xsl20/$VERSION/* cdn/release/xsl20/current
+
+# Regenerate index files
+rm -f cdn/release/xsl20/index.html
+$here/generate_index.py cdn/release/xsl20
+
+# Now prepare to commit and push to the CDN
+cd cdn
+git config user.name "Travis CI"
+git config user.email "travis-ci"
+
+git add .
+git commit -m "Deploy XSL 2.0 Stylesheets to GitHub Pages: ${SHA}"
+git push -q origin HEAD

--- a/.travis/publish-release.sh
+++ b/.travis/publish-release.sh
@@ -1,20 +1,34 @@
 #!/bin/bash
 set -e # Exit with nonzero exit code if anything fails
-set -x # Show me what's going on
+#set -x # Show me what's going on
 here=$(dirname "${BASH_SOURCE[0]}")
 # Only commits to master should trigger deployment
 # (add 'travis' for testing purposes.)
+
+VERSION=`grep "^version=" < gradle.properties | cut -f2 -d=`
 
 # debugging things
 #set | grep TRAVIS
 #pwd
 #whoami
 
-VERSION=`grep "^version=" < gradle.properties | cut -f2 -d=`
+if [ "$TRAVIS_REPO_SLUG" != "docbook/xslt20-stylesheets" ]; then
+    echo "Skipping deploy for $TRAVIS_REPO_SLUG"
+    exit 0
+fi
 
-if [ "$TRAVIS_PULL_REQUEST" != "false" ] || \
-   [ "$TRAVIS_BRANCH" != master -a "$TRAVIS_BRANCH" != travis ]; then
-    echo "Skipping deployment"
+if [ "$TRAVIS_TAG" == "" ]; then
+    echo "Skipping deploy for untagged commit."
+    exit 0
+fi
+
+if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+    echo "Skipping deploy for pull request."
+    exit 0
+fi
+
+if [ "$TRAVIS_BRANCH" != "master" -a "$TRAVIS_BRANCH" != "travis" ]; then
+    echo "Skipping deploy for branch: $TRAVIS_BRANCH"
     exit 0
 fi
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=2.3.2
+version=2.3.3
 saxonVersion=9.8.0-8
 xmlCalabashVersion=1.1.19-98
 resourcesVersion=2.0.0


### PR DESCRIPTION
Note:
* I've moved the releases to releases/xsl20 parallel to the 1.0 releases.
* I've added a current release link.
