### PR TITLE
Fixing <footnoteref/> target

### DIFF
--- a/xslt/base/html/footnotes.xsl
+++ b/xslt/base/html/footnotes.xsl
@@ -37,7 +37,7 @@
 
 <xsl:template match="db:footnoteref">
   <xsl:variable name="footnote" select="key('id',@linkend)[1]"/>
-  <xsl:variable name="href" select="concat('#ftn.', f:node-id(.))"/>
+  <xsl:variable name="href" select="concat('#ftn.', f:node-id($footnote))"/>
 
   <sup>
     <xsl:sequence select="f:html-attributes(.)"/>


### PR DESCRIPTION
Prior to fix, the `<a href>` would point to the identifier of the `<footnoteref/>`, not to the on of the `linkend` `<footnote>`.  
It now links the to text corresponding to the `<footnote>` .