### PR TITLE
Fix windows paths

### DIFF
--- a/src/main/groovy/org/docbook/DocBookTask.groovy
+++ b/src/main/groovy/org/docbook/DocBookTask.groovy
@@ -92,14 +92,18 @@ class DocBookTask extends XMLCalabashTask {
     @Override
     protected void setupRuntime() {
         XSLT20 docbook = new XSLT20()
-        String catalog = "file://" + docbook.createCatalog(catalogFilename)
+
+        File catfile = new File(docbook.createCatalog(catalogFilename));
+        String catalog = catfile.toURI().toASCIIString();
 
         String schemaCatalog = null
         try {
             Class klass = Class.forName("org.docbook.Schemas")
             Object schemas = klass.newInstance()
             Method method = schemas.getClass().getMethod("createCatalog")
-            schemaCatalog = "file://" + method.invoke(schemas)
+
+            catfile = new File(method.invoke(schemas).toString());
+            schemaCatalog = catfile.toURI().toASCIIString();
         } catch (ClassNotFoundException cfne) {
             logger.debug("DocBookTask did not find org.docbook.Schemas class");
         }

--- a/src/main/java/org/docbook/XSLT20.java
+++ b/src/main/java/org/docbook/XSLT20.java
@@ -259,7 +259,11 @@ public class XSLT20 {
         XProcConfiguration config = new XProcConfiguration(proctype, schemaAware);
         XProcRuntime runtime = new XProcRuntime(config);
 
-        String baseURI = "file://" + System.getProperty("user.dir") + "/";
+        File cwdFile = new File(System.getProperty("user.dir"));
+        String baseURI = cwdFile.toURI().toASCIIString();
+        if (!baseURI.endsWith("/")) {
+            baseURI = baseURI + "/";
+        }
 
         XdmNode source = runtime.parse(sourcefn, baseURI);
 

--- a/xslt/base/pipelines/db-foprint.xpl
+++ b/xslt/base/pipelines/db-foprint.xpl
@@ -30,7 +30,7 @@
 </p:declare-step>
 
 <p:choose name="final-pass">
-  <p:when test="$style = 'docbook'">
+  <p:when test="$style = 'docbook' or $style = 'publishers'">
     <p:output port="result" primary="true"/>
     <p:output port="secondary" sequence="true">
       <p:pipe step="fo-docbook" port="secondary"/>


### PR DESCRIPTION
The XSLT20 component that creates a catalog for files in the JAR was creating invalid URIs on Windows.
