### PR TITLE
Fixing <footnoteref/> target

### DIFF
--- a/xslt/base/common/gentext.xsl
+++ b/xslt/base/common/gentext.xsl
@@ -604,7 +604,7 @@ a cross-reference.</para>
             <xsl:with-param name="xrefstyle" select="$xrefstyle"/>
             <xsl:with-param name="title">
               <xsl:choose>
-                <xsl:when test="$title = $ghost:marker">
+                <xsl:when test="count($title) = 1 and $title is $ghost:marker">
                   <xsl:apply-templates select="." mode="m:title-content">
 		    <xsl:with-param name="allow-anchors" select="$allow-anchors"/>
 		    <xsl:with-param name="verbose" select="$verbose"/>

--- a/xslt/base/common/title-content.xsl
+++ b/xslt/base/common/title-content.xsl
@@ -53,6 +53,7 @@
     <xsl:with-param name="title" select="$title"/>
     <xsl:with-param name="subtitle" select="$subtitle"/>
     <xsl:with-param name="label" select="$label"/>
+    <xsl:with-param name="allow-anchors" select="$allow-anchors"/>
   </xsl:call-template>
 </xsl:template>
 


### PR DESCRIPTION
Passing this PR through to the DocBook project. See https://github.com/docbook/xslt20-stylesheets/pull/119

Prior to fix, the <a href> would point to the identifier of the <footnoteref/>, not to the on of the linkend <footnote>.
It now links the to text corresponding to the <footnote> .