### PR TITLE
Upgrade build environment; fix Saxon 9.9 issues

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -12,6 +12,6 @@ dependencies {
   compile (
     [group: 'com.nwalsh', name: 'nwalsh-annotations', version: '1.0.1'],
     // FIXME: this should use ../gradle.properties...
-    [group: 'net.sf.saxon', name: 'Saxon-HE', version: "9.8.0-14"],
+    [group: 'net.sf.saxon', name: 'Saxon-HE', version: "9.9.1-5"],
   )
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=2.3.11
+version=2.3.12
 saxonVersion=9.9.1-4
 xmlCalabashVersion=1.1.27-99
 resourcesVersion=2.0.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 version=2.3.11
-saxonVersion=9.8.0-14
-xmlCalabashVersion=1.1.24-98
+saxonVersion=9.9.1-4
+xmlCalabashVersion=1.1.27-99
 resourcesVersion=2.0.0
 
 snapshot=

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/xslt/base/common/dbfunctions.xsl
+++ b/xslt/base/common/dbfunctions.xsl
@@ -111,10 +111,10 @@ lines should be removed from the specified verbatim environment.</para>
 
   <xsl:choose>
     <xsl:when test="empty($trim)">
-      <xsl:value-of select="string($verbatim.trim.blank.lines) != '0'"/>
+      <xsl:sequence select="string($verbatim.trim.blank.lines) != '0'"/>
     </xsl:when>
     <xsl:otherwise>
-      <xsl:value-of select="string($trim[last()]) != '0'"/>
+      <xsl:sequence select="string($trim[last()]) != '0'"/>
     </xsl:otherwise>
   </xsl:choose>
 </xsl:function>
@@ -370,7 +370,7 @@ not have a title, it returns “???”.</para>
 
 <xsl:function name="f:length-in-points" as="xs:double">
   <xsl:param name="length" as="xs:string"/>
-  <xsl:value-of select="f:length-in-points($length, 10)"/>
+  <xsl:sequence select="f:length-in-points($length, 10)"/>
 </xsl:function>
 
 <xsl:function name="f:length-in-points" as="xs:double">

--- a/xslt/base/common/functions.xsl
+++ b/xslt/base/common/functions.xsl
@@ -353,15 +353,15 @@ elements to the list of components, if necessary.</para>
 <xsl:function name="f:is-component" as="xs:boolean">
   <xsl:param name="node" as="element()"/>
 
-  <xsl:value-of select="if ($node/self::db:appendix
-			    | $node/self::db:article
-			    | $node/self::db:chapter
-			    | $node/self::db:preface
-			    | $node/self::db:bibliography
-			    | $node/self::db:glossary
-			    | $node/self::db:index)
-			then true()
-			else false()"/>
+  <xsl:sequence select="if ($node/self::db:appendix
+                            | $node/self::db:article
+                            | $node/self::db:chapter
+                            | $node/self::db:preface
+                            | $node/self::db:bibliography
+                            | $node/self::db:glossary
+                            | $node/self::db:index)
+                        then true()
+                        else false()"/>
 </xsl:function>
 
 <!-- ====================================================================== -->
@@ -396,19 +396,19 @@ elements to the list of sections, if necessary.</para>
 <xsl:function name="f:is-section" as="xs:boolean">
   <xsl:param name="node" as="element()"/>
 
-  <xsl:value-of select="if ($node/self::db:section
-			    | $node/self::db:sect1
-			    | $node/self::db:sect2
-			    | $node/self::db:sect3
-			    | $node/self::db:sect4
-			    | $node/self::db:sect5
-			    | $node/self::db:refsect1
-			    | $node/self::db:refsect2
-			    | $node/self::db:refsect3
-			    | $node/self::db:refsection
-			    | $node/self::db:simplesect)
-			 then true()
-			 else false()"/>
+  <xsl:sequence select="if ($node/self::db:section
+                            | $node/self::db:sect1
+                            | $node/self::db:sect2
+                            | $node/self::db:sect3
+                            | $node/self::db:sect4
+                            | $node/self::db:sect5
+                            | $node/self::db:refsect1
+                            | $node/self::db:refsect2
+                            | $node/self::db:refsect3
+                            | $node/self::db:refsection
+                            | $node/self::db:simplesect)
+                         then true()
+                         else false()"/>
 </xsl:function>
 
 <!-- ============================================================ -->

--- a/xslt/base/fo/fo.xsl
+++ b/xslt/base/fo/fo.xsl
@@ -118,15 +118,15 @@
   </xsl:choose>
 </xsl:param>
 
-<xsl:function name="f:hsize" as="xs:decimal">
+<xsl:function name="f:hsize" as="xs:double">
   <xsl:param name="size" as="xs:integer"/>
 
   <xsl:choose>
     <xsl:when test="$size &lt;= 0">
-      <xsl:value-of select="$body.font.master"/>
+      <xsl:sequence select="$body.font.master"/>
     </xsl:when>
     <xsl:otherwise>
-      <xsl:value-of select="f:hsize($size - 1) * 1.2"/>
+      <xsl:sequence select="f:hsize($size - 1) * 1.2"/>
     </xsl:otherwise>
   </xsl:choose>
 </xsl:function>
@@ -136,7 +136,7 @@
 <xsl:function name="f:keep-titlepage-fragment" as="xs:boolean">
   <xsl:param name="fragment" as="node()*"/>
 
-  <xsl:value-of select="string($fragment) != ''
+  <xsl:sequence select="string($fragment) != ''
                         or count($fragment//fo:block) != count($fragment//*)"/>
 </xsl:function>
 

--- a/xslt/base/html/html.xsl
+++ b/xslt/base/html/html.xsl
@@ -542,8 +542,8 @@ for the specified node.</para>
 <xsl:function name="f:keep-titlepage-fragment" as="xs:boolean">
   <xsl:param name="fragment" as="node()*"/>
 
-  <xsl:value-of select="string($fragment) != ''
-                        or count($fragment//h:div) != count($fragment//*)"/>
+  <xsl:sequence select="string($fragment) != ''
+                          or count($fragment//h:div) != count($fragment//*)"/>
 </xsl:function>
 
 <xsl:template name="t:default-titlepage-template" as="element()">

--- a/xslt/base/preprocess/lib/normalize-cals.xsl
+++ b/xslt/base/preprocess/lib/normalize-cals.xsl
@@ -75,9 +75,9 @@ each row and cell.</para>
 <!--
   <xsl:message>
     <xsl:text>ROW </xsl:text>
-    <xsl:value-of select="count(preceding-sibling::db:row)+1"/>
+    <xsl:sequence select="count(preceding-sibling::db:row)+1"/>
     <xsl:text> </xsl:text>
-    <xsl:value-of select="$overhang" separator=","/>
+    <xsl:sequence select="$overhang" separator=","/>
   </xsl:message>
 -->
 
@@ -128,23 +128,23 @@ each row and cell.</para>
 	<xsl:variable name="name" select="@namest"/>
 	<xsl:variable name="colspec"
 		      select="$container/db:colspec[@colname=$name]"/>
-	<xsl:value-of select="f:colspec-colnum($colspec)"/>
+	<xsl:sequence select="f:colspec-colnum($colspec)"/>
       </xsl:when>
       <xsl:when test="@colname">
 	<xsl:variable name="name" select="@colname"/>
 	<xsl:variable name="colspec"
 		      select="$container/db:colspec[@colname=$name]"/>
-	<xsl:value-of select="f:colspec-colnum($colspec)"/>
+	<xsl:sequence select="f:colspec-colnum($colspec)"/>
       </xsl:when>
       <xsl:when test="@spanname">
 	<xsl:variable name="name" select="@spanname"/>
 	<xsl:variable name="spanspec"
 		      select="$container/db:spanspec[@spanname=$name]"/>
 
-	<xsl:value-of select="f:spanspec-colnum-start($spanspec)"/>
+	<xsl:sequence select="f:spanspec-colnum-start($spanspec)"/>
       </xsl:when>
       <xsl:otherwise>
-	<xsl:value-of select="$nextpos"/>
+	<xsl:sequence select="$nextpos"/>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:variable>
@@ -156,14 +156,14 @@ each row and cell.</para>
 	<xsl:variable name="colspec"
 		      select="$container/db:colspec[@colname=$name]"/>
 
-	<xsl:value-of select="f:colspec-colnum($colspec) - $pos + 1"/>
+	<xsl:sequence select="f:colspec-colnum($colspec) - $pos + 1"/>
       </xsl:when>
       <xsl:when test="@spanname">
 	<xsl:variable name="name" select="@spanname"/>
 	<xsl:variable name="spanspec"
 		      select="$container/db:spanspec[@spanname=$name]"/>
 
-	<xsl:value-of select="f:spanspec-colnum-end($spanspec) - $pos + 1"/>
+	<xsl:sequence select="f:spanspec-colnum-end($spanspec) - $pos + 1"/>
       </xsl:when>
       <xsl:otherwise>1</xsl:otherwise>
     </xsl:choose>
@@ -172,11 +172,11 @@ each row and cell.</para>
 <!--
   <xsl:message>
     <xsl:text>  ENT </xsl:text>
-    <xsl:value-of select="count(preceding-sibling::db:entry)+1"/>
+    <xsl:sequence select="count(preceding-sibling::db:entry)+1"/>
     <xsl:text> </xsl:text>
-    <xsl:value-of select="$pos"/>
+    <xsl:sequence select="$pos"/>
     <xsl:text>, </xsl:text>
-    <xsl:value-of select="$width"/>
+    <xsl:sequence select="$width"/>
   </xsl:message>
 -->
 
@@ -225,11 +225,11 @@ each row and cell.</para>
 
   <!--
   <xsl:message>
-    <xsl:value-of select="$pos"/>
+    <xsl:sequence select="$pos"/>
     <xsl:text>, </xsl:text>
-    <xsl:value-of select="count(following-sibling::*)"/>
+    <xsl:sequence select="count(following-sibling::*)"/>
     <xsl:text>, </xsl:text>
-    <xsl:value-of select="$container/@cols"/>
+    <xsl:sequence select="$container/@cols"/>
   </xsl:message>
   -->
 
@@ -245,9 +245,9 @@ each row and cell.</para>
 <!--
     <xsl:message>
       <xsl:text>  PAD </xsl:text>
-      <xsl:value-of select="$pos+$width"/>
+      <xsl:sequence select="$pos+$width"/>
       <xsl:text>-</xsl:text>
-      <xsl:value-of select="$container/@cols"/>
+      <xsl:sequence select="$container/@cols"/>
     </xsl:message>
 -->
     <xsl:for-each select="for $col
@@ -441,12 +441,12 @@ be an integer and won't have a parent.</para>
     <xsl:variable name="value">
       <xsl:choose>
 	<xsl:when test="f:find-element-by-attribute($elements, $attr)">
-	  <xsl:value-of select="f:find-element-by-attribute($elements, $attr)
+	  <xsl:sequence select="f:find-element-by-attribute($elements, $attr)
 				/@*[node-name(.) = $attr]"/>
 	</xsl:when>
 	<xsl:otherwise>
 	  <xsl:if test="$attr=QName('','rowsep') or $attr=QName('','colsep')">
-	    <xsl:value-of select="1"/>
+	    <xsl:sequence select="1"/>
 	  </xsl:if>
 	</xsl:otherwise>
       </xsl:choose>
@@ -632,10 +632,10 @@ current column number.</para>
 
   <xsl:choose>
     <xsl:when test="$pos &gt; count($overhang)">
-      <xsl:value-of select="$pos"/>
+      <xsl:sequence select="$pos"/>
     </xsl:when>
     <xsl:otherwise>
-      <xsl:value-of select="if ($overhang[$pos] = 0)
+      <xsl:sequence select="if ($overhang[$pos] = 0)
 			    then $pos
 			    else f:skip-overhang($overhang, $pos+1)"/>
     </xsl:otherwise>
@@ -673,10 +673,10 @@ current column number.</para>
 
   <xsl:choose>
     <xsl:when test="$colspec/@colnum">
-      <xsl:value-of select="$colspec/@colnum"/>
+      <xsl:sequence select="$colspec/@colnum"/>
     </xsl:when>
     <xsl:when test="$colspec/preceding-sibling::db:colspec">
-      <xsl:value-of select="f:colspec-colnum(
+      <xsl:sequence select="f:colspec-colnum(
 			       $colspec/preceding-sibling::db:colspec[1])
 	                    + 1"/>
     </xsl:when>
@@ -717,7 +717,7 @@ span.</para>
 <xsl:function name="f:spanspec-colnum-start" as="xs:integer">
   <xsl:param name="spanspec" as="element(db:spanspec)"/>
 
-  <xsl:value-of select="f:colspec-colnum($spanspec/ancestor::db:tgroup[1]
+  <xsl:sequence select="f:colspec-colnum($spanspec/ancestor::db:tgroup[1]
 			      /db:colspec[@colname=$spanspec/@namest])"/>
 </xsl:function>
 
@@ -751,8 +751,8 @@ of a span.</para>
 <xsl:function name="f:spanspec-colnum-end" as="xs:integer">
   <xsl:param name="spanspec" as="element(db:spanspec)"/>
 
-  <xsl:value-of select="f:colspec-colnum($spanspec/ancestor::db:tgroup[1]
-			      /db:colspec[@colname=$spanspec/@nameend])"/>
+  <xsl:sequence select="f:colspec-colnum($spanspec/ancestor::db:tgroup[1]
+                              /db:colspec[@colname=$spanspec/@nameend])"/>
 </xsl:function>
 
 <!-- ============================================================ -->
@@ -840,10 +840,10 @@ See <function role="named-template">generate-colgroup</function>.
       <xsl:variable name="colspec.colnum">
 	<xsl:choose>
 	  <xsl:when test="$colspec/@colnum">
-            <xsl:value-of select="$colspec/@colnum"/>
+            <xsl:sequence select="$colspec/@colnum"/>
           </xsl:when>
           <xsl:otherwise>
-            <xsl:value-of select="$colnum"/>
+            <xsl:sequence select="$colnum"/>
           </xsl:otherwise>
         </xsl:choose>
       </xsl:variable>
@@ -855,10 +855,10 @@ See <function role="named-template">generate-colgroup</function>.
 	      <xsl:attribute name="width">
 		<xsl:choose>
 		  <xsl:when test="normalize-space($colspec/@colwidth) = '*'">
-		    <xsl:value-of select="'1*'"/>
+		    <xsl:sequence select="'1*'"/>
 		  </xsl:when>
 		  <xsl:otherwise>
-		    <xsl:value-of select="$colspec/@colwidth"/>
+		    <xsl:sequence select="$colspec/@colwidth"/>
 		  </xsl:otherwise>
 		</xsl:choose>
 	      </xsl:attribute>
@@ -867,26 +867,26 @@ See <function role="named-template">generate-colgroup</function>.
 	    <xsl:choose>
 	      <xsl:when test="$colspec/@align">
 		<xsl:attribute name="align">
-		  <xsl:value-of select="$colspec/@align"/>
+		  <xsl:sequence select="$colspec/@align"/>
 		</xsl:attribute>
 	      </xsl:when>
 	      <!-- Suggested by Pavel ZAMPACH <zampach@nemcb.cz> -->
 	      <xsl:when test="$colspecs/parent::db:tgroup/@align">
 		<xsl:attribute name="align">
-                  <xsl:value-of select="$colspecs/parent::db:tgroup/@align"/>
+                  <xsl:sequence select="$colspecs/parent::db:tgroup/@align"/>
 		</xsl:attribute>
               </xsl:when>
             </xsl:choose>
 
 	    <xsl:if test="$colspec/@char">
               <xsl:attribute name="char">
-                <xsl:value-of select="$colspec/@char"/>
+                <xsl:sequence select="$colspec/@char"/>
               </xsl:attribute>
             </xsl:if>
 
             <xsl:if test="$colspec/@charoff">
               <xsl:attribute name="charoff">
-                <xsl:value-of select="$colspec/@charoff"/>
+                <xsl:sequence select="$colspec/@charoff"/>
               </xsl:attribute>
             </xsl:if>
 	  </col>
@@ -899,10 +899,10 @@ See <function role="named-template">generate-colgroup</function>.
             <xsl:with-param name="colnum">
               <xsl:choose>
                 <xsl:when test="$colspec/@colnum">
-                  <xsl:value-of select="$colspec/@colnum + 1"/>
+                  <xsl:sequence select="$colspec/@colnum + 1"/>
                 </xsl:when>
                 <xsl:otherwise>
-                  <xsl:value-of select="$colnum + 1"/>
+                  <xsl:sequence select="$colnum + 1"/>
                 </xsl:otherwise>
               </xsl:choose>
             </xsl:with-param>


### PR DESCRIPTION
Saxon 9.9 introduced a new warning for functions that use `xsl:value-of` to return atomic types. This release attempts to fix those warnings. It also updates the build infrastructure to the most recent Gradle and Saxon 9.9.
