### PR TITLE
Fix resolver

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,7 @@ dependencies {
   compile (
     [group: 'net.sf.saxon', name: 'Saxon-HE', version: saxonVersion],
     [group: 'org.relaxng', name: 'jing', version: '20181222' ],
+    [group: 'org.xmlresolver', name: 'xmlresolver', version: '1.0.3'],
     [group: 'com.xmlcalabash', name: 'xmlcalabash', version: xmlCalabashVersion],
     [group: 'com.xmlcalabash', name: 'xmlcalabash1-gradle', version: '1.3.5'],
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=2.3.14
+version=2.3.15
 saxonVersion=9.9.1-4
 xmlCalabashVersion=1.1.27-99
 resourcesVersion=2.0.0

--- a/src/main/java/org/docbook/XSLT20.java
+++ b/src/main/java/org/docbook/XSLT20.java
@@ -186,6 +186,8 @@ public class XSLT20 {
                 tempcat = new File(catalogFilename);
             }
 
+            logger.debug("Transient catalog file: " + tempcat.getAbsolutePath());
+
             PrintStream catstream = new PrintStream(tempcat);
             catstream.print(xformed.toString());
             catstream.close();

--- a/src/main/resources/etc/make-catalog.xsl
+++ b/src/main/resources/etc/make-catalog.xsl
@@ -26,11 +26,11 @@
                 select="if (starts-with($name, '/resources/'))
                         then $resourcesVersion
                         else $version"/>
-  <xsl:for-each select="('latest', $rsrcver)">
+  <xsl:for-each select="('current', $rsrcver)">
     <xsl:variable name="path"
                   select="if (starts-with($name, '/resources/'))
                           then concat('resources/', ., substring-after($name, '/resources'))
-                          else concat('release/', ., $name)"/>
+                          else concat('release/xsl20/', ., $name)"/>
     <uri xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
       <xsl:attribute name="name" select="concat($https, $path)"/>
       <xsl:attribute name="uri" select="concat($jarloc, $name)"/>


### PR DESCRIPTION
Some time ago, the layout of documents on cdn.docbook.org changed. The dynamically generated catalog in the stylesheet distribution was never updated to reflect these changes. This release fixes that bug. It also references the most recent XML Resolver to correct for bugs related to caching URIs.
