### PR TITLE
Resolve preferentially against the JAR file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ dependencies {
   compile (
     [group: 'net.sf.saxon', name: 'Saxon-HE', version: saxonVersion],
     [group: 'org.relaxng', name: 'jing', version: '20181222' ],
-    [group: 'org.xmlresolver', name: 'xmlresolver', version: '1.0.3'],
+    [group: 'org.xmlresolver', name: 'xmlresolver', version: '1.0.4'],
     [group: 'com.xmlcalabash', name: 'xmlcalabash', version: xmlCalabashVersion],
     [group: 'com.xmlcalabash', name: 'xmlcalabash1-gradle', version: '1.3.5'],
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=2.3.15
+version=2.3.16
 saxonVersion=9.9.1-4
 xmlCalabashVersion=1.1.27-99
 resourcesVersion=2.0.0

--- a/src/main/java/org/docbook/XSLT20.java
+++ b/src/main/java/org/docbook/XSLT20.java
@@ -347,10 +347,10 @@ public class XSLT20 {
 
         @Override
         public Source resolve(String href, String base) throws TransformerException {
-            // We go last
-            Source src = nextResolver.resolve(href, base);
+            // We go first
+            Source src = resolver.resolve(href, base);
             if (src == null) {
-                return resolver.resolve(href, base);
+                return nextResolver.resolve(href, base);
             } else {
                 return src;
             }


### PR DESCRIPTION
Initially, I thought the JAR file should be the location of last resort. I've changed it now to be the preferential location. Neither is perfect, but this seems better. (It means if you have an out-of-date entry in one of your catalogs, it won't prevent you from getting newer versions from the JAR file.)