### PR TITLE
Fix refpage formatting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,7 @@ configurations {
 dependencies {
   implementation fileTree(dir: 'lib').include("*.jar")
   implementation (
+    [group: 'com.nwalsh', name: 'nwalsh-annotations', version: '1.0.0'],
     [group: 'net.sf.saxon', name: 'Saxon-HE', version: saxonVersion],
     [group: 'org.relaxng', name: 'jing', version: '20181222' ],
     [group: 'org.xmlresolver', name: 'xmlresolver', version: '1.0.5'],
@@ -469,14 +470,6 @@ task sourcesJar(type: Jar) {
   from sourceSets.main.allSource
 }
 
-/*
-artifacts {
-  archives jar
-  archives sourcesJar
-  archives javadocJar
-}
-*/
-
 task makeVersionProperties() {
   doFirst {
     mkdir("build/stage/jar/etc")
@@ -539,7 +532,7 @@ jar {
     attributes "DynamicImport-Package": "*"
     // This is a bit of a hack; special case the three most likely
     // commercial jar files for printing with CSS or FO.
-    attributes"Class-Path": project.ext.runtimeClasspath \
+    attributes "Class-Path": project.ext.runtimeClasspath \
               + " lib/XfoJavaCtl.jar lib/xep.jar lib/prince.jar"
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
-relVersion=2.5.0
+relVersion=2.5.1
 saxonVersion=9.9.1-7
-xmlCalabashVersion=1.1.30-99
+xmlCalabashVersion=1.2.0-99
 resourcesVersion=2.1.1
 
 snapshot=

--- a/tools/test/printtest.xpl
+++ b/tools/test/printtest.xpl
@@ -53,9 +53,9 @@
   </p:load>
 
   <dbp:docbook>
-    <p:with-param name="resource.root" select="resolve-uri('../resources/')"/>
+    <p:with-param name="resource.root" select="resolve-uri('../../build/test/resources/')"/>
     <p:with-param name="bibliography.collection"
-                  select="'../../test/resources/bibliography.xml'"/>
+                  select="'../../build/test/resources/bibliography.xml'"/>
     <p:with-param name="profile.os" select="'win'"/>
     <p:with-option name="style"
                    select="if (/*/db:info/p:style)

--- a/xslt/base/fo/refentry.xsl
+++ b/xslt/base/fo/refentry.xsl
@@ -12,39 +12,41 @@
 <xsl:template match="db:reference|db:refentry">
   <xsl:variable name="master-reference" select="f:select-pagemaster(.)"/>
 
-  <fo:page-sequence hyphenate="{$hyphenate}"
-                    master-reference="{$master-reference}">
-    <xsl:call-template name="t:page-sequence-attributes"/>
+  <xsl:if test="empty(parent::*)">
+    <fo:page-sequence hyphenate="{$hyphenate}"
+                      master-reference="{$master-reference}">
+      <xsl:call-template name="t:page-sequence-attributes"/>
 
-    <xsl:apply-templates select="." mode="m:running-head-mode">
-      <xsl:with-param name="master-reference" select="$master-reference"/>
-    </xsl:apply-templates>
-
-    <xsl:apply-templates select="." mode="m:running-foot-mode">
-      <xsl:with-param name="master-reference" select="$master-reference"/>
-    </xsl:apply-templates>
-
-    <fo:flow flow-name="xsl-region-body">
-      <xsl:call-template name="t:flow-properties">
-        <xsl:with-param name="element" select="local-name(.)"/>
+      <xsl:apply-templates select="." mode="m:running-head-mode">
         <xsl:with-param name="master-reference" select="$master-reference"/>
-      </xsl:call-template>
+      </xsl:apply-templates>
 
-      <xsl:call-template name="t:titlepage"/>
+      <xsl:apply-templates select="." mode="m:running-foot-mode">
+        <xsl:with-param name="master-reference" select="$master-reference"/>
+      </xsl:apply-templates>
 
-      <xsl:variable name="toc.params"
-                    select="f:find-toc-params(., $generate.toc)"/>
+      <fo:flow flow-name="xsl-region-body">
+        <xsl:call-template name="t:flow-properties">
+          <xsl:with-param name="element" select="local-name(.)"/>
+          <xsl:with-param name="master-reference" select="$master-reference"/>
+        </xsl:call-template>
 
-      <xsl:call-template name="make-lots">
-        <xsl:with-param name="toc.params" select="$toc.params"/>
-        <xsl:with-param name="toc">
-          <xsl:call-template name="division-toc">
-            <xsl:with-param name="toc.title" select="$toc.params/@title != 0"/>
-          </xsl:call-template>
-        </xsl:with-param>
-      </xsl:call-template>
-    </fo:flow>
-  </fo:page-sequence>
+        <xsl:call-template name="t:titlepage"/>
+
+        <xsl:variable name="toc.params"
+                      select="f:find-toc-params(., $generate.toc)"/>
+
+        <xsl:call-template name="make-lots">
+          <xsl:with-param name="toc.params" select="$toc.params"/>
+          <xsl:with-param name="toc">
+            <xsl:call-template name="division-toc">
+              <xsl:with-param name="toc.title" select="$toc.params/@title != 0"/>
+            </xsl:call-template>
+          </xsl:with-param>
+        </xsl:call-template>
+      </fo:flow>
+    </fo:page-sequence>
+  </xsl:if>
   <xsl:apply-templates/>
 </xsl:template>
 

--- a/xslt/base/html/refentry.xsl
+++ b/xslt/base/html/refentry.xsl
@@ -32,7 +32,7 @@
 
 <xsl:template match="db:refnamediv">
   <div>
-    <xsl:sequence select="f:html-attributes(.)"/>
+    <xsl:sequence select="f:html-attributes(., f:node-id(.))"/>
 
     <xsl:choose>
       <xsl:when test="$refentry.generate.name">
@@ -99,7 +99,7 @@
 
 <xsl:template match="db:refsynopsisdiv">
   <div>
-    <xsl:sequence select="f:html-attributes(.)"/>
+    <xsl:sequence select="f:html-attributes(., f:node-id(.))"/>
 
     <h2>
       <xsl:choose>
@@ -120,7 +120,7 @@
 
 <xsl:template match="db:refsection|db:refsect1|db:refsect2|db:refsect3">
   <div>
-    <xsl:sequence select="f:html-attributes(.)"/>
+    <xsl:sequence select="f:html-attributes(., f:node-id(.))"/>
 
     <xsl:call-template name="t:titlepage"/>
 


### PR DESCRIPTION
Mostly this PR fixes two bugs in refpage formatting:

1. In the HTML stylesheets, there are no IDs on refsections
2. In the FO stylesheets, incorrect fo:page-sequence elements were inserted

I also cleaned up the build and advanced the version of XML Calabash.