### PR TITLE
Fix missing version in docbook-xslt2 jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -517,6 +517,7 @@ task copyJar(type: Copy, dependsOn: [ "jar" ]) {
 
 jar {
   archiveBaseName = "docbook-xslt2"
+  archiveVersion = relVersion
   manifest {
     attributes "Built-By": builtBy
     attributes "Implementation-Vendor": "Norman Walsh"


### PR DESCRIPTION
The "jar" target was missing a version number, so would produce `docbook-xslt2.jar` instead of the expected `docbook-xslt2-x.y.z.jar`.  This causes the "zipApp" target to create a zip which contains dependencies, but not the application!  This has affected all releases since 2.4.3.