### PR TITLE
update to gradle 8.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 /buildSrc/build/
 # Local libraries that should not be committed or distributed
 /lib/
+.idea/
+*.hprof

--- a/build.gradle
+++ b/build.gradle
@@ -39,13 +39,14 @@ import de.undercouch.gradle.tasks.download.Download
 repositories {
   mavenLocal()
   mavenCentral()
-  maven { url "https://maven.restlet.com" }
+  // maven { url "https://maven.restlet.com" }
 }
 
 configurations.all {
   resolutionStrategy {
     force 'xml-apis:xml-apis:1.4.01'
   }
+  exclude group: 'org.restlet.jee'
 }
 
 configurations {
@@ -57,8 +58,7 @@ configurations {
 dependencies {
   implementation fileTree(dir: 'lib').include("*.jar")
   implementation (
-    [group: 'com.nwalsh', name: 'nwalsh-annotations', version: '1.0.0'],
-    [group: 'net.sf.saxon', name: 'Saxon-HE', version: saxonVersion],
+    [group: 'com.nwalsh', name: 'nwalsh-annotations', version: '1.0.1'],
     [group: 'org.relaxng', name: 'jing', version: '20181222' ],
     [group: 'org.xmlresolver', name: 'xmlresolver', version: '1.0.5'],
     [group: 'com.xmlcalabash', name: 'xmlcalabash', version: xmlCalabashVersion],
@@ -67,6 +67,7 @@ dependencies {
     // 1.2 because that's what gradleApi requires :-(
     [group: 'commons-cli', name: 'commons-cli', version: '1.2']
   )
+  implementation("net.sf.saxon:Saxon-HE:${saxonVersion}")
 
   runtimeOnly (
     [group: 'org.relaxng', name: 'trang', version: '20181222' ],
@@ -76,10 +77,11 @@ dependencies {
   pluginApi gradleApi()
 }
 
-// Assuming the pattern for Saxon versions is 1.2.3-4
+// Assuming the pattern for Saxon versions is 1.2
 int pos = saxonVersion.indexOf(".")
 String major = saxonVersion.substring(0, pos)
 String temp = saxonVersion.substring(pos+1)
+/*
 pos = temp.indexOf(".")
 String minor = temp.substring(0, pos)
 pos = saxonVersion.indexOf("-")
@@ -88,6 +90,11 @@ project.ext.saxonRelease = saxonVersion.substring(0,pos)
 project.ext.saxonBranch  = major + minor
 project.ext.releaseVersion = relVersion
 project.ext.distVersion = relVersion + "-" + saxonBranch + snapshot
+ */
+project.ext.saxonRelease = saxonVersion
+project.ext.saxonBranch  = major + temp
+project.ext.releaseVersion = relVersion
+project.ext.distVersion = saxonVersion
 
 if (!hasProperty("sonatypeUsername")) {
   ext.sonatypeUsername=""
@@ -98,6 +105,7 @@ if (!hasProperty("sonatypePassword")) {
 }
 
 compileGroovy {
+  dependsOn("setupResources")
   classpath += configurations.pluginApi
 }
 
@@ -461,12 +469,14 @@ task stageJar(type: Copy, dependsOn: [ "compileXslt", "makeUris",
 processResources.dependsOn stageJar
 
 task javadocJar(type: Jar, dependsOn: javadoc) {
-  classifier = 'javadoc'
+  // classifier = 'javadoc'
+  getArchiveClassifier().set("javadoc")
   from javadoc.destinationDir
 }
 
 task sourcesJar(type: Jar) {
-  classifier = 'sources'
+  // classifier = 'sources'
+  getArchiveClassifier().set("sources")
   from sourceSets.main.allSource
 }
 

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -9,9 +9,7 @@ repositories {
 }
 
 dependencies {
-  implementation (
-    [group: 'com.nwalsh', name: 'nwalsh-annotations', version: '1.0.1'],
-    // FIXME: this should use ../gradle.properties...
-    [group: 'net.sf.saxon', name: 'Saxon-HE', version: "9.9.1-7"],
-  )
+  implementation("com.nwalsh:nwalsh-annotations:1.0.1")
+  // FIXME: this should use ../gradle.properties...
+  implementation("net.sf.saxon:Saxon-HE:9.9.1-7")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,8 @@
 relVersion=2.6.0
-saxonVersion=9.9.1-7
-xmlCalabashVersion=1.2.0-99
+# saxonVersion>10.9 use CatalogResolver instead on Catalog and ArrayIterator is different
+saxonVersion=10.9
+# xmlCalabashVersion>=1.2.4-100 don't have NodeInfo.getAllNamespaces
+xmlCalabashVersion=1.2.4-99
 resourcesVersion=2.1.1
 
 snapshot=
@@ -19,3 +21,7 @@ pre_print_css=tools/test/ann-to-footnotes.xsl
 post_print_css=
 pre_print_fo=
 post_print_fo=
+
+org.gradle.jvmargs=-Xmx4096m
+org.gradle.parallel=true
+org.gradle.cache=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.2.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradletest/build.gradle
+++ b/gradletest/build.gradle
@@ -3,7 +3,7 @@ buildscript {
     maven { url uri('/tmp/repo') }
     mavenLocal()
     mavenCentral()
-    maven { url "http://maven.restlet.org" }
+    // maven { url "http://maven.restlet.org" }
   }
 
   dependencies {
@@ -18,6 +18,13 @@ buildscript {
 repositories {
   mavenLocal()
   mavenCentral()
+}
+
+configurations.all {
+  resolutionStrategy {
+    force 'xml-apis:xml-apis:1.4.01'
+  }
+  exclude group: 'org.restlet.jee'
 }
 
 import org.docbook.DocBookTask


### PR DESCRIPTION
* Changes to use Gradle 8.2 (instead of 6.2.2) for building. 
* This (also) allows to build with Java 17. 
* Also upgraded saxon-he and xmlcalabash to the latest possible versions without (java) code changes
* Removed (unneeded?) dependency to restlet